### PR TITLE
Upgrade the React repository automation to WebStudio 6.4.0

### DIFF
--- a/src/main/java/configuration/core/ui/WebElement.java
+++ b/src/main/java/configuration/core/ui/WebElement.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -94,12 +95,10 @@ public class WebElement {
      * overlay is still up after the timeout we proceed and let Playwright's own actionability retry.
      */
     public static void waitForAppReady(Page page, long timeoutMs) {
-        try {
-            page.waitForFunction(
-                    "() => !document.querySelector('" + LOADING_OVERLAY_SELECTOR + "')",
-                    null,
-                    new Page.WaitForFunctionOptions().setTimeout(timeoutMs));
-        } catch (RuntimeException ignored) {
+        boolean ready = WaitUtil.waitForCondition(
+                () -> page.locator(LOADING_OVERLAY_SELECTOR).count() == 0,
+                timeoutMs, 150, "Waiting for the loading overlay to disappear");
+        if (!ready) {
             LOGGER.debug("Loading overlay still present after {}ms; proceeding and relying on actionability retry", timeoutMs);
         }
     }
@@ -116,16 +115,21 @@ public class WebElement {
      * {@link #waitForAppReady} can return mid-recompile while JSF nodes are still detaching. Never throws.
      */
     public static void waitForAppIdle(Page page, long timeoutMs) {
-        try {
-            page.evaluate("() => { window.__openlIdleSince = 0; }");
-            page.waitForFunction(
-                    "() => { const now = performance.now();" +
-                    " if (document.querySelector('" + LOADING_OVERLAY_SELECTOR + "')) { window.__openlIdleSince = 0; return false; }" +
-                    " if (!window.__openlIdleSince) { window.__openlIdleSince = now; return false; }" +
-                    " return (now - window.__openlIdleSince) >= 750; }",
-                    null,
-                    new Page.WaitForFunctionOptions().setTimeout(timeoutMs));
-        } catch (RuntimeException ignored) {
+        long quietWindowMs = 750;
+        long[] overlayAbsentSince = {0};
+        boolean idle = WaitUtil.waitForCondition(() -> {
+            long now = System.currentTimeMillis();
+            if (page.locator(LOADING_OVERLAY_SELECTOR).count() > 0) {
+                overlayAbsentSince[0] = 0;
+                return false;
+            }
+            if (overlayAbsentSince[0] == 0) {
+                overlayAbsentSince[0] = now;
+                return false;
+            }
+            return now - overlayAbsentSince[0] >= quietWindowMs;
+        }, timeoutMs, 150, "Waiting for the loading overlay to stay absent for a quiet window");
+        if (!idle) {
             LOGGER.debug("App still busy after {}ms; proceeding and relying on actionability retry", timeoutMs);
         }
     }
@@ -344,9 +348,7 @@ public class WebElement {
         List<String> optionLabels = locator.locator("option").allTextContents().stream()
                 .map(String::trim)
                 .toList();
-        @SuppressWarnings("unchecked")
-        List<String> optionValues = (List<String>) locator.locator("option")
-                .evaluateAll("options => options.map(option => option.value || '')");
+        List<String> optionValues = getSelectValues();
         if (optionLabels.contains(text)) {
             retryOnReRenderChurn(() -> locator.selectOption(new SelectOption().setLabel(text)));
         } else if (optionValues.contains(text)) {
@@ -357,11 +359,17 @@ public class WebElement {
         }
     }
 
-    @SuppressWarnings("unchecked")
     public List<String> getSelectValues() {
         isVisible();
         LOGGER.info("Getting select option values from {}", elementName);
-        return (List<String>) locator.locator("option").evaluateAll("options => options.map(option => option.value || '')");
+        Locator options = locator.locator("option");
+        List<String> values = new ArrayList<>();
+        int count = options.count();
+        for (int i = 0; i < count; i++) {
+            String value = options.nth(i).getAttribute("value");
+            values.add(value != null ? value : "");
+        }
+        return values;
     }
 
     public List<String> getSelectVisibleTextValues() {
@@ -372,7 +380,7 @@ public class WebElement {
 
     public String getSelectedOptionText() {
         LOGGER.info("Getting selected option text from {}", elementName);
-        return (String) locator.evaluate("el => el.options[el.selectedIndex].text");
+        return locator.locator("option:checked").textContent();
     }
     
     public WebElement child(String subSelector) {
@@ -482,6 +490,7 @@ public class WebElement {
     
     // CSS properties
     
+    // Playwright exposes no computed-style API, so getComputedStyle via evaluate is the only mechanism.
     public String getCssValue(String propertyName) {
         LOGGER.info("Getting CSS property '{}' from {}", propertyName, elementName);
         return locator.evaluate("el => window.getComputedStyle(el).getPropertyValue('" + propertyName + "')").toString();

--- a/src/main/java/domain/ui/webstudio/components/BaseComponent.java
+++ b/src/main/java/domain/ui/webstudio/components/BaseComponent.java
@@ -38,14 +38,9 @@ public abstract class BaseComponent extends CoreComponent {
     }
 
     public void waitUntilSpinnerLoaded() {
+        // waitForHidden covers both "detached" and "display:none", so the legacy #loadingPanel is handled here;
+        // then wait out the new React full-screen loading overlay (EPBDS-16241 replaced #loadingPanel).
         contentLoadingSpinner.waitForHidden(30000);
-        try {
-            page.waitForFunction(
-                    "() => { const lp = document.querySelector('#loadingPanel'); return !lp || getComputedStyle(lp).display === 'none'; }",
-                    new Page.WaitForFunctionOptions().setTimeout(5000));
-        } catch (RuntimeException ignored) {
-        }
-        // Also wait out the new React full-screen loading overlay (EPBDS-16241 replaced #loadingPanel).
         WebElement.waitForAppReady(page);
     }
 

--- a/src/main/java/domain/ui/webstudio/components/common/CreateNewProjectComponent.java
+++ b/src/main/java/domain/ui/webstudio/components/common/CreateNewProjectComponent.java
@@ -37,6 +37,9 @@ public class CreateNewProjectComponent extends BaseComponent {
     private WebElement archiveUpload; // file input on the "From archive" (.zip) step
     private WebElement methodOpenApi;
     private WebElement openApiUpload; // file input on the "From OpenAPI" step (data/rules modules auto-fill)
+    private WebElement repoSelect;    // new-project-repo (ant-select) — target design repository (shown with >1 repo)
+    private WebElement repoOption;    // body-level ant-select option, format(repoName)
+    private WebElement pathField;     // new-project-path (path-in-repository for non-flat repos)
 
     public CreateNewProjectComponent() {
         super(LocalDriverPool.getPage());
@@ -70,6 +73,40 @@ public class CreateNewProjectComponent extends BaseComponent {
         archiveUpload = new WebElement(LocalDriverPool.getPage(), "[data-testid=new-project-upload]", "archiveUpload");
         methodOpenApi = new WebElement(LocalDriverPool.getPage(), "[data-testid=new-project-method-openapi]", "methodOpenApi");
         openApiUpload = new WebElement(LocalDriverPool.getPage(), "[data-testid=new-project-openapi-upload]", "openApiUpload");
+        repoSelect = new WebElement(LocalDriverPool.getPage(), "[data-testid=new-project-repo]", "newProjectRepo");
+        repoOption = new WebElement(LocalDriverPool.getPage(), "xpath=//div[contains(@class,'ant-select-item-option')][.//*[normalize-space(text())='%s'] or @title='%s']", "newProjectRepoOption");
+        pathField = new WebElement(LocalDriverPool.getPage(), "[data-testid=new-project-path]", "newProjectPath");
+    }
+
+    // --- React create-wizard target-repository + path controls (visible on the form step once >1 design repo
+    // exists). Used by multi-repo tests to create/copy into a specific repository at a given path. ---
+    public CreateNewProjectComponent selectRepository(String repositoryName) {
+        repoSelect.waitForVisible(5000);
+        repoSelect.click();
+        repoOption.format(repositoryName, repositoryName).click();
+        return this;
+    }
+
+    public String getRepositorySelectValue() {
+        return repoSelect.getText().trim();
+    }
+
+    public boolean isPathInRepositoryVisible() {
+        return pathField.isVisible(3000);
+    }
+
+    public String getPathInRepositoryValue() {
+        return pathField.getCurrentInputValue();
+    }
+
+    public CreateNewProjectComponent setPathInRepository(String path) {
+        pathField.clear();
+        pathField.fill(path);
+        return this;
+    }
+
+    public void clickCreate() {
+        submitBtn.click();
     }
 
     // Full create-from-template path in the React wizard (method -> Next -> group -> item -> name -> Create).
@@ -155,7 +192,7 @@ public class CreateNewProjectComponent extends BaseComponent {
     }
 
     public void cancelCreation() {
-        closeDialogBtn.click();
+        cancelBtn.click();
     }
 
     @Getter

--- a/src/main/java/domain/ui/webstudio/components/common/CreateNewProjectComponent.java
+++ b/src/main/java/domain/ui/webstudio/components/common/CreateNewProjectComponent.java
@@ -27,7 +27,6 @@ public class CreateNewProjectComponent extends BaseComponent {
     private WebElement methodTemplate;
     private WebElement methodExcel;
     private WebElement methodArchive;
-    private WebElement nextBtn;
     private WebElement cancelBtn;
     private WebElement submitBtn;
     private WebElement nameField;
@@ -63,7 +62,6 @@ public class CreateNewProjectComponent extends BaseComponent {
         methodTemplate = new WebElement(LocalDriverPool.getPage(), "[data-testid=new-project-method-template]", "methodTemplate");
         methodExcel = new WebElement(LocalDriverPool.getPage(), "[data-testid=new-project-method-excel]", "methodExcel");
         methodArchive = new WebElement(LocalDriverPool.getPage(), "[data-testid=new-project-method-archive]", "methodArchive");
-        nextBtn = new WebElement(LocalDriverPool.getPage(), "[data-testid=new-project-next]", "newProjectNext");
         cancelBtn = new WebElement(LocalDriverPool.getPage(), "[data-testid=new-project-cancel]", "newProjectCancel");
         submitBtn = new WebElement(LocalDriverPool.getPage(), "[data-testid=new-project-submit]", "newProjectSubmit");
         nameField = new WebElement(LocalDriverPool.getPage(), "[data-testid=new-project-name]", "newProjectName");
@@ -109,7 +107,7 @@ public class CreateNewProjectComponent extends BaseComponent {
         submitBtn.click();
     }
 
-    // Full create-from-template path in the React wizard (method -> Next -> group -> item -> name -> Create).
+    // Full create-from-template path in the React wizard (method -> group -> item -> name -> Create).
     public void createProjectFromTemplate(String templateName, String projectName) {
         createProjectFromTemplate(templateName, projectName, true);
     }
@@ -117,7 +115,6 @@ public class CreateNewProjectComponent extends BaseComponent {
     // submit=false opens the wizard and fills the form without pressing Create (partial flows).
     public void createProjectFromTemplate(String templateName, String projectName, boolean submit) {
         methodTemplate.click();
-        nextBtn.click();
         if (templateName != null && !templateName.isEmpty()) {
             templateGroup.format(groupOf(templateName)).click();
             templateItem.format(templateName).click();
@@ -137,10 +134,9 @@ public class CreateNewProjectComponent extends BaseComponent {
         return "templates";
     }
 
-    // Create-from-Excel path in the React wizard (method -> Next -> upload .xlsx -> name -> Create).
+    // Create-from-Excel path in the React wizard (method -> upload .xlsx -> name -> Create).
     public void createProjectFromExcel(String excelFileName, String projectName) {
         methodExcel.click();
-        nextBtn.click();
         excelUpload.setInputFiles(TestDataUtil.getFilePathFromResources(excelFileName));
         if (projectName != null && !projectName.isEmpty()) {
             nameField.fill(projectName);
@@ -148,10 +144,9 @@ public class CreateNewProjectComponent extends BaseComponent {
         submitBtn.click();
     }
 
-    // Create-from-archive path in the React wizard (method -> Next -> upload .zip -> name -> Create).
+    // Create-from-archive path in the React wizard (method -> upload .zip -> name -> Create).
     public void createProjectFromZip(String zipFileName, String projectName) {
         methodArchive.click();
-        nextBtn.click();
         archiveUpload.setInputFiles(TestDataUtil.getFilePathFromResources(zipFileName));
         if (projectName != null && !projectName.isEmpty()) {
             nameField.fill(projectName);
@@ -159,11 +154,10 @@ public class CreateNewProjectComponent extends BaseComponent {
         submitBtn.click();
     }
 
-    // Create-from-OpenAPI path in the React wizard (method -> Next -> upload spec -> name -> Create).
+    // Create-from-OpenAPI path in the React wizard (method -> upload spec -> name -> Create).
     // The data/rules module name and path fields auto-populate from the uploaded spec.
     public void createProjectFromOpenApi(String fileName, String projectName, boolean submit) {
         methodOpenApi.click();
-        nextBtn.click();
         openApiUpload.setInputFiles(TestDataUtil.getFilePathFromResources(fileName));
         if (projectName != null && !projectName.isEmpty()) {
             nameField.fill(projectName);

--- a/src/main/java/domain/ui/webstudio/components/common/TableComponent.java
+++ b/src/main/java/domain/ui/webstudio/components/common/TableComponent.java
@@ -81,8 +81,8 @@ public class TableComponent extends BaseComponent {
             return true;
         }, 10000, 500, "Activating cell editor for cell [" + rowIndex + "," + columnIndex + "]");
 
-        String editorTag = inputLocator.getLocator().evaluate("el => el.tagName.toLowerCase()").toString();
-        if ("select".equals(editorTag)) {
+        boolean isSelectEditor = inputLocator.getLocator().locator("xpath=self::select").count() > 0;
+        if (isSelectEditor) {
             inputLocator.selectByVisibleText(text);
             if (pressEnter) {
                 inputLocator.press("Enter");

--- a/src/main/java/domain/ui/webstudio/components/editortabcomponents/EditorToolbarPanelComponent.java
+++ b/src/main/java/domain/ui/webstudio/components/editortabcomponents/EditorToolbarPanelComponent.java
@@ -804,29 +804,36 @@ public class EditorToolbarPanelComponent extends BaseComponent {
             } else {
                 topPanelWithinCurrentModuleOnly.uncheck();
             }
-            page.waitForFunction(
-                    "() => new Promise(resolve => setTimeout(() => {" +
-                            " const cb = document.querySelector('#testModuleOnlyField');" +
-                            " resolve(!!cb && cb.checked === " + value + " && !cb.disabled);" +
-                            "}, 750))",
-                    null,
-                    new Page.WaitForFunctionOptions().setTimeout(1200));
+            boolean settled = WaitUtil.waitForCondition(
+                    () -> topPanelWithinCurrentModuleOnly.isChecked() == value
+                            && topPanelWithinCurrentModuleOnly.isEnabled(),
+                    1200, 200, "Waiting for WithinCurrentModuleOnly to settle at " + value);
+            if (!settled) {
+                throw new RuntimeException("WithinCurrentModuleOnly did not settle at " + value);
+            }
         }, 10000, 250, "Setting top panel WithinCurrentModuleOnly to " + value);
     }
 
+    // Waits until the checkbox's (checked, enabled) state stays unchanged for a short quiet window, i.e.
+    // the server round-trip that can flip/disable it during a recompile has settled.
     private void waitForTopPanelWithinCurrentModuleOnlyToStabilize() {
-        page.waitForFunction(
-                "() => new Promise(resolve => {" +
-                        " const cb = document.querySelector('#testModuleOnlyField');" +
-                        " if (!cb) { resolve(false); return; }" +
-                        " const state = cb.checked + ':' + cb.disabled;" +
-                        " setTimeout(() => {" +
-                        "   const current = document.querySelector('#testModuleOnlyField');" +
-                        "   resolve(!!current && (current.checked + ':' + current.disabled) === state);" +
-                        " }, 750);" +
-                        "})",
-                null,
-                new Page.WaitForFunctionOptions().setTimeout(10000));
+        long stableWindowMs = 750;
+        String[] lastState = {null};
+        long[] stableSince = {0};
+        WaitUtil.waitForCondition(() -> {
+            if (topPanelWithinCurrentModuleOnly.getLocator().count() == 0) {
+                lastState[0] = null;
+                return false;
+            }
+            String state = topPanelWithinCurrentModuleOnly.isChecked() + ":" + topPanelWithinCurrentModuleOnly.isEnabled();
+            long now = System.currentTimeMillis();
+            if (!state.equals(lastState[0])) {
+                lastState[0] = state;
+                stableSince[0] = now;
+                return false;
+            }
+            return now - stableSince[0] >= stableWindowMs;
+        }, 10000, 150, "Waiting for WithinCurrentModuleOnly checkbox state to stabilize");
     }
 
     // ========== Run/Trace/Benchmark Dropdown Arrows ==========

--- a/src/main/java/domain/ui/webstudio/components/editortabcomponents/RightTableDetailsComponent.java
+++ b/src/main/java/domain/ui/webstudio/components/editortabcomponents/RightTableDetailsComponent.java
@@ -48,6 +48,17 @@ public class RightTableDetailsComponent extends BaseComponent {
     private WebElement selectAllCheckbox;
     private WebElement multiselectCheckboxTemplate;
 
+    // RichFaces calendar popup (readonly date inputs are picked via the widget, scoped to the one open popup)
+    private WebElement calMonthLabel;
+    private WebElement calPrevYear;
+    private WebElement calNextYear;
+    private WebElement calPrevMonth;
+    private WebElement calNextMonth;
+    private WebElement calDayTemplate;
+
+    private static final List<String> MONTHS = List.of("January", "February", "March", "April", "May", "June",
+            "July", "August", "September", "October", "November", "December");
+
     private void initializeElements() {
         addPropertyLink = createScopedElement("xpath=.//a[@id='addPropBtn']", "addPropertyLink");
         propertyTypeSelector = createScopedElement("xpath=.//div[@id='addPropsPanel']//select", "propertyTypeSelector");
@@ -76,6 +87,17 @@ public class RightTableDetailsComponent extends BaseComponent {
         // Multi-select popup
         selectAllCheckbox = createScopedElement("xpath=//div[@class='jquery-multiselect-popup jquery-popup']//label[text()='Select All']//..//input", "selectAllCheckbox");
         multiselectCheckboxTemplate = createScopedElement("xpath=//div[@class='jquery-multiselect-popup jquery-popup']//div[@class='jquery-multiselect-popup-data']//input[@value='%s']", "multiselectCheckbox");
+
+        // RichFaces calendar: scope to the single open popup (.rf-cal-popup:visible); nav cells and days by text.
+        String visiblePopup = ".rf-cal-popup:visible >> ";
+        calMonthLabel = new WebElement(getPage(), visiblePopup + "css=.rf-cal-hdr-month", "calMonthLabel");
+        calPrevYear = new WebElement(getPage(), visiblePopup + "xpath=.//td[contains(@class,'rf-cal-tl') and normalize-space(.)='<<']", "calPrevYear");
+        calNextYear = new WebElement(getPage(), visiblePopup + "xpath=.//td[contains(@class,'rf-cal-tl') and normalize-space(.)='>>']", "calNextYear");
+        calPrevMonth = new WebElement(getPage(), visiblePopup + "xpath=.//td[contains(@class,'rf-cal-tl') and normalize-space(.)='<']", "calPrevMonth");
+        calNextMonth = new WebElement(getPage(), visiblePopup + "xpath=.//td[contains(@class,'rf-cal-tl') and normalize-space(.)='>']", "calNextMonth");
+        calDayTemplate = new WebElement(getPage(), visiblePopup
+                + "xpath=.//td[(contains(@class,'rf-cal-btn') or contains(@class,'rf-cal-sel') or contains(@class,'rf-cal-today'))"
+                + " and not(contains(@class,'rf-cal-boundary-day')) and normalize-space(.)='%s']", "calDay");
 
     }
 
@@ -201,17 +223,43 @@ public class RightTableDetailsComponent extends BaseComponent {
         }
     }
 
+    // The date property is a readonly RichFaces calendar, so the value is picked through the widget: open the
+    // popup, navigate to the target month/year, and click the day (which commits "MM/DD/YYYY 12:00 AM" and closes).
     public void editDateProperty(String propertyName, String dateValue) {
         clickPropertyValue(propertyName);
-        WebElement input = propertyTextInputTemplate.format(propertyName);
-        String dateTimeValue = dateValue + " 12:00 AM";
-        input.getLocator().evaluate("(el) => {"
-                + "el.value = '" + dateTimeValue + "';"
-                + "el.dispatchEvent(new Event('input', { bubbles: true }));"
-                + "el.dispatchEvent(new Event('change', { bubbles: true }));"
-                + "el.dispatchEvent(new Event('blur', { bubbles: true }));"
-                + "}");
-        WaitUtil.sleep(200, "Waiting after entering date property value");
+        propertyTextInputTemplate.format(propertyName).click();
+        calMonthLabel.waitForVisible(DEFAULT_TIMEOUT_MS);
+        String[] parts = dateValue.split("/");
+        int targetMonth = Integer.parseInt(parts[0]);
+        int targetDay = Integer.parseInt(parts[1]);
+        int targetYear = Integer.parseInt(parts[2]);
+        navigateCalendarTo(targetMonth, targetYear);
+        calDayTemplate.format(String.valueOf(targetDay)).click();
+        WaitUtil.sleep(200, "Waiting after picking the date");
+    }
+
+    private void navigateCalendarTo(int targetMonth, int targetYear) {
+        int targetIndex = targetYear * 12 + (targetMonth - 1);
+        for (int guard = 0; guard < 240; guard++) {
+            int[] current = readCalendarMonthYear();
+            int currentIndex = current[1] * 12 + (current[0] - 1);
+            if (currentIndex == targetIndex) {
+                return;
+            }
+            if (currentIndex > targetIndex) {
+                (current[1] > targetYear ? calPrevYear : calPrevMonth).click();
+            } else {
+                (current[1] < targetYear ? calNextYear : calNextMonth).click();
+            }
+            WaitUtil.sleep(150, "Calendar navigation step");
+        }
+        throw new IllegalStateException("Calendar did not reach " + targetMonth + "/" + targetYear);
+    }
+
+    // Reads the popup header label "Month, YYYY" (e.g. "July, 2026") into [month(1-12), year].
+    private int[] readCalendarMonthYear() {
+        String[] label = calMonthLabel.getText().trim().split(",");
+        return new int[]{MONTHS.indexOf(label[0].trim()) + 1, Integer.parseInt(label[1].trim())};
     }
 
     public void deleteProperty(String propertyName) {

--- a/src/main/java/domain/ui/webstudio/components/editortabcomponents/leftmenu/EditorLeftRulesTreeComponent.java
+++ b/src/main/java/domain/ui/webstudio/components/editortabcomponents/leftmenu/EditorLeftRulesTreeComponent.java
@@ -85,7 +85,7 @@ public class EditorLeftRulesTreeComponent extends BaseComponent {
                 100,
                 "Searching for visible leaf node '" + itemName + "' in editor tree")
                 .orElseThrow(() -> new RuntimeException(String.format("Visible leaf node with name %s not found", itemName)));
-        leafNode.getLocator().evaluate("node => { const link = node.querySelector('a'); if (!link) throw new Error('Leaf link not found'); const href = link.getAttribute('href'); if (!href) throw new Error('Leaf href not found'); window.location.hash = href.replace(/^#/, ''); }");
+        leafNode.child("a").click();
         return this;
     }
 

--- a/src/main/java/domain/ui/webstudio/components/repositorytabcomponents/CompareGitRevisionsDialogComponent.java
+++ b/src/main/java/domain/ui/webstudio/components/repositorytabcomponents/CompareGitRevisionsDialogComponent.java
@@ -1,5 +1,6 @@
 package domain.ui.webstudio.components.repositorytabcomponents;
 
+import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.LoadState;
 import configuration.core.ui.WebElement;
@@ -63,7 +64,7 @@ public class CompareGitRevisionsDialogComponent extends BaseComponent {
                 "xpath=//input[@id='compareForm:compareBtn']",
                 "compareBtnInPopup");
         showEqualRowsCheckbox = new WebElement(getPage(),
-                "xpath=//input[contains(@id,'compareForm:compareBtn')]/preceding-sibling::input[@type='checkbox'][1]",
+                "xpath=//input[contains(@id,'showEqualElements')]",
                 "showEqualRowsCheckbox");
         treeNodeLabels = new WebElement(getPage(),
                 "xpath=//span[contains(@class,'rf-trn-lbl')]",
@@ -78,12 +79,14 @@ public class CompareGitRevisionsDialogComponent extends BaseComponent {
         treeNodeLinkTemplate = new WebElement(getPage(),
                 "xpath=//span[contains(@class,'rf-trn-lbl') and normalize-space(.)='%s']",
                 "treeNodeLinkTemplate");
-        // idSuffix pattern: "1_te_c-7:5" - uses ends-with to avoid substring collisions (e.g. c-2:1 vs c-2:10)
+        // React repo-compare renders the diff in a standalone showDiff.xhtml tab whose JSF form id is dynamic
+        // (e.g. j_idt11), so the fragment is addressed by the Nth "_te_table" div and cells by their id suffix
+        // "_te_c-<row>:<col>" (%1$s = fragment 1/2, %2$s = the cell-id suffix).
         cellTemplate = new WebElement(getPage(),
-                "xpath=//td[(contains(@id,'diffTreeForm') or contains(@id,'compareRevisionsForm')) and (substring(@id, string-length(@id) - string-length('%1$s') + 1) = '%1$s')]",
+                "xpath=(//div[substring(@id, string-length(@id) - 8) = '_te_table'])[%1$s]//td[substring(@id, string-length(@id) - string-length('%2$s') + 1) = '%2$s']",
                 "cellTemplate");
         editorRowsTemplate = new WebElement(getPage(),
-                "xpath=//div[@id='diffTreeForm:editor%1$s_te_table' or @id='compareRevisionsForm:editor%1$s_te_table']//tr[./td]",
+                "xpath=(//div[substring(@id, string-length(@id) - 8) = '_te_table'])[%1$s]//tr[./td]",
                 "editorRowsTemplate");
     }
 
@@ -173,8 +176,8 @@ public class CompareGitRevisionsDialogComponent extends BaseComponent {
     }
 
     public boolean isCellHighlightedWithColor(int row, int col, String fragment, String colorRGBA) {
-        String idSuffix = fragment + "_te_c-" + row + ":" + col;
-        WebElement cell = cellTemplate.format(idSuffix);
+        String idSuffix = "_te_c-" + row + ":" + col;
+        WebElement cell = cellTemplate.format(fragment, idSuffix);
         cell.waitForVisible(5000);
         String actualColor = cell.getCssValue("background-color");
         LOGGER.info("Repo cell background-color at [{},{}] fragment={}: {}", row, col, fragment, actualColor);
@@ -183,21 +186,34 @@ public class CompareGitRevisionsDialogComponent extends BaseComponent {
 
     // ========== Row counting (repository-specific locator) ==========
 
+    // showDiff.xhtml renders the whole table in the DOM and hides equal rows via CSS when "Show equal
+    // elements" is off, so count only the VISIBLE rows (the old build removed equal rows from the DOM).
     public int getNumberOfRows(int fragment) {
-        WaitUtil.waitForCondition(
-                () -> editorRowsTemplate.format(String.valueOf(fragment)).getLocator().count() > 0,
-                10000,
-                250,
+        Locator rows = editorRowsTemplate.format(String.valueOf(fragment)).getLocator();
+        WaitUtil.waitForCondition(() -> rows.count() > 0, 10000, 250,
                 "Waiting for repository comparison rows to appear for fragment " + fragment);
-        return editorRowsTemplate.format(String.valueOf(fragment)).getLocator().count();
+        int total = rows.count();
+        int visible = 0;
+        for (int i = 0; i < total; i++) {
+            if (rows.nth(i).isVisible()) {
+                visible++;
+            }
+        }
+        return visible;
     }
 
     // ========== Show Equal Rows ==========
 
+    // Toggling "Show equal elements" re-renders the whole diff (the tree collapses), so callers must
+    // re-navigate the tree afterwards; here we just flip it and wait for the tree to rebuild.
+    // Flips the "Show equal elements" checkbox and waits for the diff to re-render. NOTE: on this build's
+    // showDiff.xhtml the toggle no longer removes equal rows from the fragment tables (the diff always renders
+    // the full table with changed cells highlighted), so it is a UI-state toggle rather than a row filter.
     public void setShowEqualRows(boolean value) {
         if (showEqualRowsCheckbox.isChecked() != value) {
             showEqualRowsCheckbox.click();
-            WaitUtil.sleep(300, "Waiting for showEqualRows toggle in repo compare");
+            WaitUtil.sleep(500, "Waiting for diff re-render after show-equal toggle in repo compare");
+            waitForComparisonTreeToLoad();
         }
     }
 

--- a/src/main/java/domain/ui/webstudio/components/repositorytabcomponents/CopyProjectDialogComponent.java
+++ b/src/main/java/domain/ui/webstudio/components/repositorytabcomponents/CopyProjectDialogComponent.java
@@ -1,6 +1,5 @@
 package domain.ui.webstudio.components.repositorytabcomponents;
 
-import com.microsoft.playwright.Dialog;
 import configuration.core.ui.WebElement;
 import configuration.driver.LocalDriverPool;
 import domain.ui.webstudio.components.BaseComponent;
@@ -10,24 +9,26 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
+// React "Copy project" dialog (build 032c60a664ce+), opened from a project row's Copy action.
+// Fields (verified live): copy-project-repository (ant-select), copy-project-name, copy-project-path,
+// copy-project-comment, copy-project-submit. The legacy branch / separate-project / copy-old-revisions
+// options were removed in React (their setters are kept as no-op shims so not-yet-migrated legacy tests
+// still compile).
 public class CopyProjectDialogComponent extends BaseComponent {
 
     private static final Logger LOGGER = LogManager.getLogger(CopyProjectDialogComponent.class);
 
-    private WebElement newBranchNameField;
+    private static final String MODAL_ROOT =
+            "//div[contains(@class,'ant-modal')][.//*[contains(@data-testid,'copy-project')]]";
+
+    private WebElement newProjectNameField;
+    private WebElement projectFolderField;
+    private WebElement commentField;
     private WebElement copyButton;
     private WebElement cancelButton;
-    private WebElement currentProjectNameDisplay;
-    private WebElement currentBranchDisplay;
-    private WebElement newProjectNameField;
-    private WebElement commentField;
-    private WebElement copyOldVersionCheckbox;
-    private WebElement revisionsCountField;
-    private WebElement separateProjectCheckbox;
     private WebElement repositorySelect;
-    private WebElement projectFolderField;
+    private WebElement repositoryOption;
     private List<WebElement> errors;
-    private String expectedNewBranchName;
 
     public CopyProjectDialogComponent() {
         super(LocalDriverPool.getPage());
@@ -40,30 +41,14 @@ public class CopyProjectDialogComponent extends BaseComponent {
     }
 
     private void initializeElements() {
-        newBranchNameField = createScopedElement("xpath=.//input[@id='copyProjectForm:newBranchName']", "newBranchNameField");
-        copyButton = createScopedElement("xpath=.//form[@id='copyProjectForm']//input[@value='Copy']", "copyButton");
-        cancelButton = createScopedElement("xpath=.//form[@id='copyProjectForm']//input[@value='Cancel']", "cancelButton");
-        currentProjectNameDisplay = createScopedElement("xpath=.//div[@id='copyProjectForm:currentProjectName']", "currentProjectNameDisplay");
-        currentBranchDisplay = createScopedElement("xpath=.//span[@id='copyProjectForm:currentBranchName']", "currentBranchDisplay");
-        newProjectNameField = createScopedElement("xpath=.//input[@id='copyProjectForm:newProjectName']", "newProjectNameField");
-        commentField = createScopedElement("xpath=.//textarea[@id='copyProjectForm:comment']", "commentField");
-        copyOldVersionCheckbox = createScopedElement("xpath=.//input[@id='copyProjectForm:copyOldRevisions']", "copyOldVersionCheckbox");
-        revisionsCountField = createScopedElement("xpath=.//input[@name='copyProjectForm:revisionsCount']", "revisionsCountField");
-        separateProjectCheckbox = createScopedElement("xpath=.//input[@id='copyProjectForm:separateProjectCheckbox']", "separateProjectCheckbox");
-        repositorySelect = createScopedElement("xpath=.//select[@id='copyProjectForm:repository']", "repositorySelect");
-        projectFolderField = createScopedElement("xpath=.//input[@id='copyProjectForm:projectFolder']", "projectFolderField");
-        errors = createScopedElementList("xpath=.//span[@class='error']", "errors");
-    }
-
-    public CopyProjectDialogComponent setNewBranchName(String branchName) {
-        LOGGER.info("Setting new branch name: {}", branchName);
-        expectedNewBranchName = branchName;
-        fillNewBranchName(branchName);
-        return this;
-    }
-
-    public String getNewBranchName() {
-        return newBranchNameField.getCurrentInputValue();
+        newProjectNameField = new WebElement(page, "[data-testid=copy-project-name]", "copyProjectName");
+        projectFolderField = new WebElement(page, "[data-testid=copy-project-path]", "copyProjectPath");
+        commentField = new WebElement(page, "[data-testid=copy-project-comment]", "copyProjectComment");
+        copyButton = new WebElement(page, "[data-testid=copy-project-submit]", "copyProjectSubmit");
+        cancelButton = new WebElement(page, "xpath=" + MODAL_ROOT + "//div[contains(@class,'ant-modal-footer')]//button[not(contains(@class,'ant-btn-primary'))]", "copyProjectCancel");
+        repositorySelect = new WebElement(page, "[data-testid=copy-project-repository]", "copyProjectRepository");
+        repositoryOption = new WebElement(page, "xpath=//div[contains(@class,'ant-select-item-option')][.//*[normalize-space(text())='%s'] or @title='%s']", "copyProjectRepoOption");
+        errors = createElementList("xpath=" + MODAL_ROOT + "//div[contains(@class,'ant-form-item-explain-error')] | " + MODAL_ROOT + "//div[contains(@class,'ant-alert-error')]", "copyProjectErrors");
     }
 
     public CopyProjectDialogComponent setNewProjectName(String projectName) {
@@ -73,71 +58,29 @@ public class CopyProjectDialogComponent extends BaseComponent {
     }
 
     public String getNewProjectName() {
-        return newProjectNameField.getAttribute("value");
+        return newProjectNameField.getCurrentInputValue();
     }
 
     public CopyProjectDialogComponent setComment(String comment) {
-        LOGGER.info("Setting copy comment");
         commentField.fill(comment);
         return this;
     }
 
-    public String getComment() {
-        return commentField.getAttribute("value");
-    }
-
-    public CopyProjectDialogComponent setCopyOldVersion(boolean enabled) {
-        if (enabled) {
-            copyOldVersionCheckbox.check();
-        } else {
-            copyOldVersionCheckbox.uncheck();
-        }
-        return this;
-    }
-
-    public CopyProjectDialogComponent setRevisionsCount(String count) {
-        revisionsCountField.fill(count);
-        return this;
-    }
-
-    public CopyProjectDialogComponent setSeparateProject(boolean enabled) {
-        if (enabled) {
-            separateProjectCheckbox.check();
-        } else {
-            separateProjectCheckbox.uncheck();
-        }
-        return this;
-    }
-
     public CopyProjectDialogComponent selectRepository(String repositoryName) {
-        // The repository select fires JSF AJAX (mojarra.ab) on change which re-renders
-        // the newProject table including projectFolder. Use waitForResponse to ensure
-        // the AJAX completes before we attempt to fill the path field.
-        repositorySelect.getPage().waitForResponse(
-                response -> response.url().contains("index.xhtml"),
-                () -> repositorySelect.selectByVisibleText(repositoryName)
-        );
+        LOGGER.info("Selecting copy target repository: {}", repositoryName);
+        repositorySelect.click();
+        repositoryOption.format(repositoryName, repositoryName).click();
         return this;
     }
 
     public CopyProjectDialogComponent setProjectFolder(String folderPath) {
         projectFolderField.clear();
-        projectFolderField.fillSequentially(folderPath);
+        projectFolderField.fill(folderPath);
         return this;
-    }
-
-    public String getCurrentProjectName() {
-        return currentProjectNameDisplay.getText();
-    }
-
-    public String getCurrentBranch() {
-        return currentBranchDisplay.getText();
     }
 
     public void clickCopyButton(boolean waitForDialogToClose) {
         LOGGER.info("Clicking Copy button");
-        ensureExpectedNewBranchName();
-        LocalDriverPool.getPage().onceDialog(Dialog::accept);
         copyButton.click();
         if (waitForDialogToClose) {
             waitForDialogToClose();
@@ -145,23 +88,21 @@ public class CopyProjectDialogComponent extends BaseComponent {
     }
 
     public void clickCopyButton() {
-        copyButton.press("Tab");
         clickCopyButton(true);
     }
 
     public void clickCancelButton() {
-        LOGGER.info("Clicking Cancel button");
         cancelButton.click();
     }
 
     public CopyProjectDialogComponent waitForDialogToAppear() {
-        getRootLocator().waitForVisible(5000);
+        newProjectNameField.waitForVisible(5000);
         return this;
     }
 
     public void waitForDialogToClose() {
         try {
-            getRootLocator().waitForHidden(5000);
+            copyButton.waitForHidden(5000);
         } catch (Exception e) {
             List<String> visibleErrors = getErrors();
             if (!visibleErrors.isEmpty()) {
@@ -180,35 +121,21 @@ public class CopyProjectDialogComponent extends BaseComponent {
         return getErrors();
     }
 
-    private void fillNewBranchName(String branchName) {
-        boolean branchNameSet = WaitUtil.retryAction(() -> {
-            WaitUtil.sleep(1000, "Extra wait for fillNewBranchName() method (before filling new branch name)");
-            newBranchNameField.waitForVisible();
-            newBranchNameField.clear();
-            newBranchNameField.fillSequentially(branchName);
-            WaitUtil.sleep(1000, "Extra wait for fillNewBranchName() method (after filling new branch name)");
-            String actualBranchName = getNewBranchName();
-            if (!branchName.equals(actualBranchName)) {
-                throw new RuntimeException(String.format(
-                        "Expected new branch name '%s', but field value is '%s'",
-                        branchName,
-                        actualBranchName
-                ));
-            }
-        }, 5000, 200, "Setting and verifying new branch name");
-
-        if (!branchNameSet) {
-            throw new RuntimeException("Failed to set new branch name to '" + branchName + "'");
-        }
+    // --- Legacy no-op/compat shims: branch / separate-project / copy-old-revisions were removed in the React
+    // copy dialog. Kept so not-yet-migrated legacy tests still compile; they are no longer functional. ---
+    public CopyProjectDialogComponent setSeparateProject(boolean enabled) {
+        return this;
     }
 
-    private void ensureExpectedNewBranchName() {
-        if (expectedNewBranchName == null) {
-            return;
-        }
+    public CopyProjectDialogComponent setNewBranchName(String branchName) {
+        return this;
+    }
 
-        if (!expectedNewBranchName.equals(getNewBranchName())) {
-            fillNewBranchName(expectedNewBranchName);
-        }
+    public String getNewBranchName() {
+        return "";
+    }
+
+    public String getCurrentBranch() {
+        return "";
     }
 }

--- a/src/main/java/domain/ui/webstudio/components/repositorytabcomponents/CopyProjectDialogComponent.java
+++ b/src/main/java/domain/ui/webstudio/components/repositorytabcomponents/CopyProjectDialogComponent.java
@@ -9,11 +9,14 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
-// React "Copy project" dialog (build 032c60a664ce+), opened from a project row's Copy action.
-// Fields (verified live): copy-project-repository (ant-select), copy-project-name, copy-project-path,
-// copy-project-comment, copy-project-submit. The legacy branch / separate-project / copy-old-revisions
-// options were removed in React (their setters are kept as no-op shims so not-yet-migrated legacy tests
-// still compile).
+/**
+ * React "Copy project" dialog, opened from a project row's Copy action.
+ *
+ * <p>Studio 6.4.0 restored the legacy capabilities the first React cut had dropped: the dialog opens in
+ * BRANCH mode (copy-project-branch) whenever the project's repository supports branching, and the
+ * copy-project-as-new checkbox switches it to NEW-PROJECT mode (name / target repository / path /
+ * comment), which also offers copying from an older revision.
+ */
 public class CopyProjectDialogComponent extends BaseComponent {
 
     private static final Logger LOGGER = LogManager.getLogger(CopyProjectDialogComponent.class);
@@ -28,6 +31,12 @@ public class CopyProjectDialogComponent extends BaseComponent {
     private WebElement cancelButton;
     private WebElement repositorySelect;
     private WebElement repositoryOption;
+    private WebElement asNewProjectCheckbox;
+    private WebElement branchField;
+    private WebElement currentBranchLabel;
+    private WebElement oldRevisionCheckbox;
+    private WebElement revisionSelect;
+    private WebElement revisionOption;
     private List<WebElement> errors;
 
     public CopyProjectDialogComponent() {
@@ -48,6 +57,12 @@ public class CopyProjectDialogComponent extends BaseComponent {
         cancelButton = new WebElement(page, "xpath=" + MODAL_ROOT + "//div[contains(@class,'ant-modal-footer')]//button[not(contains(@class,'ant-btn-primary'))]", "copyProjectCancel");
         repositorySelect = new WebElement(page, "[data-testid=copy-project-repository]", "copyProjectRepository");
         repositoryOption = new WebElement(page, "xpath=//div[contains(@class,'ant-select-item-option')][.//*[normalize-space(text())='%s'] or @title='%s']", "copyProjectRepoOption");
+        asNewProjectCheckbox = new WebElement(page, "[data-testid=copy-project-as-new]", "copyProjectAsNew");
+        branchField = new WebElement(page, "[data-testid=copy-project-branch]", "copyProjectBranch");
+        currentBranchLabel = new WebElement(page, "[data-testid=copy-project-current-branch]", "copyProjectCurrentBranch");
+        oldRevisionCheckbox = new WebElement(page, "[data-testid=copy-project-old-revision]", "copyProjectOldRevision");
+        revisionSelect = new WebElement(page, "[data-testid=copy-project-revision]", "copyProjectRevision");
+        revisionOption = new WebElement(page, "xpath=//div[contains(@class,'ant-select-item-option')][.//*[normalize-space(text())='%s'] or @title='%s']", "copyProjectRevisionOption");
         errors = createElementList("xpath=" + MODAL_ROOT + "//div[contains(@class,'ant-form-item-explain-error')] | " + MODAL_ROOT + "//div[contains(@class,'ant-alert-error')]", "copyProjectErrors");
     }
 
@@ -96,7 +111,36 @@ public class CopyProjectDialogComponent extends BaseComponent {
     }
 
     public CopyProjectDialogComponent waitForDialogToAppear() {
-        newProjectNameField.waitForVisible(5000);
+        copyButton.waitForVisible(DEFAULT_TIMEOUT_MS);
+        return this;
+    }
+
+    /**
+     * Switches the dialog into NEW-PROJECT mode (name / target repository / path). On a branching
+     * repository the dialog opens in branch mode, so copying into a new project must tick this first;
+     * where the checkbox is absent (repository without branches) the dialog is already in that mode.
+     */
+    public CopyProjectDialogComponent setAsNewProject() {
+        if (asNewProjectCheckbox.isVisible(DEFAULT_TIMEOUT_MS / 5) && !asNewProjectCheckbox.isChecked()) {
+            asNewProjectCheckbox.click();
+        }
+        newProjectNameField.waitForVisible(DEFAULT_TIMEOUT_MS);
+        return this;
+    }
+
+    /** Copies the project into a NEW branch (branch mode — the dialog's default on a git repository). */
+    public CopyProjectDialogComponent setBranchName(String branchName) {
+        branchField.waitForVisible(DEFAULT_TIMEOUT_MS).fill(branchName);
+        return this;
+    }
+
+    /** Copies from an earlier revision instead of the latest one (new-project mode only). */
+    public CopyProjectDialogComponent setOldRevision(String revisionLabel) {
+        if (!oldRevisionCheckbox.isChecked()) {
+            oldRevisionCheckbox.click();
+        }
+        revisionSelect.waitForVisible(DEFAULT_TIMEOUT_MS).click();
+        revisionOption.format(revisionLabel, revisionLabel).click();
         return this;
     }
 
@@ -121,21 +165,21 @@ public class CopyProjectDialogComponent extends BaseComponent {
         return getErrors();
     }
 
-    // --- Legacy no-op/compat shims: branch / separate-project / copy-old-revisions were removed in the React
-    // copy dialog. Kept so not-yet-migrated legacy tests still compile; they are no longer functional. ---
-    public CopyProjectDialogComponent setSeparateProject(boolean enabled) {
-        return this;
-    }
-
     public CopyProjectDialogComponent setNewBranchName(String branchName) {
-        return this;
+        return setBranchName(branchName);
     }
 
     public String getNewBranchName() {
-        return "";
+        return branchField.getCurrentInputValue();
     }
 
+    /** The branch the copied project currently sits on, as shown by the dialog. */
     public String getCurrentBranch() {
-        return "";
+        return currentBranchLabel.waitForVisible(DEFAULT_TIMEOUT_MS).getText().trim();
+    }
+
+    // "Copy as a separate project" is expressed by the as-new checkbox in 6.4.0.
+    public CopyProjectDialogComponent setSeparateProject(boolean enabled) {
+        return enabled ? setAsNewProject() : this;
     }
 }

--- a/src/main/java/domain/ui/webstudio/components/repositorytabcomponents/SaveProjectDialogComponent.java
+++ b/src/main/java/domain/ui/webstudio/components/repositorytabcomponents/SaveProjectDialogComponent.java
@@ -44,6 +44,16 @@ public class SaveProjectDialogComponent extends BaseComponent {
         submitBtn.waitForHidden(10000);
     }
 
+    // Click Submit without waiting for the dialog to close — a user's first commit raises the "Configure Git
+    // Commit Info" modal on top, so the caller fills that before the save dialog finalizes.
+    public void clickSubmit() {
+        submitBtn.click();
+    }
+
+    public void waitForSubmitHidden() {
+        submitBtn.waitForHidden(10000);
+    }
+
     public void cancel() {
         cancelBtn.click();
     }

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/LoginPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/LoginPage.java
@@ -3,15 +3,24 @@ package domain.ui.webstudio.pages.mainpages;
 import com.microsoft.playwright.Page;
 import configuration.core.ui.WebElement;
 import domain.serviceclasses.models.UserData;
+import domain.ui.webstudio.components.common.ConfigureCommitInfoComponent;
 import domain.ui.webstudio.pages.BasePage;
 import helpers.utils.WaitUtil;
 
 public class LoginPage extends BasePage {
 
+    // Studio 6.4.0 raises a mandatory "Complete Your Profile" modal on the first login of every user;
+    // it blocks the whole shell (its overlay swallows top-nav clicks) until the profile is saved.
+    private static final String COMPLETE_PROFILE_MODAL = "xpath=//div[@role='dialog']"
+            + "[.//div[contains(@class,'ant-modal-title') and normalize-space()='Complete Your Profile']]";
+    private static final String SHELL_READY_SELECTOR = ".ant-modal-wrap, ul.ant-menu-horizontal";
+
     private WebElement usernameField;
     private WebElement passwordField;
     private WebElement loginButton;
     private WebElement loginErrorMessage;
+    private WebElement completeProfileModal;
+    private ConfigureCommitInfoComponent completeProfileComponent;
 
     public LoginPage() {
         super();
@@ -28,6 +37,8 @@ public class LoginPage extends BasePage {
         passwordField = new WebElement(page, "xpath=//input[@id='password']", "passwordField");
         loginButton = new WebElement(page, "xpath=//button[@type='submit']", "loginButton");
         loginErrorMessage = new WebElement(page, "xpath=//div[contains(@class,'ant-alert-error')]", "loginErrorMessage");
+        completeProfileModal = new WebElement(page, COMPLETE_PROFILE_MODAL, "completeProfileModal");
+        completeProfileComponent = createScopedComponent(ConfigureCommitInfoComponent.class, COMPLETE_PROFILE_MODAL, "completeProfileComponent");
     }
 
     public EditorPage login(UserData user) {
@@ -39,7 +50,21 @@ public class LoginPage extends BasePage {
         usernameField.fill(user.getLogin());
         passwordField.fill(user.getPassword());
         loginButton.click();
+        completeProfileIfRequested();
         return new EditorPage();
+    }
+
+    /**
+     * Fills the 6.4.0 "Complete Your Profile" modal when the logged-in user has no profile yet.
+     * Waits for either the modal or the loaded shell so a returning user costs no extra timeout.
+     */
+    public void completeProfileIfRequested() {
+        page.waitForSelector(SHELL_READY_SELECTOR,
+                new Page.WaitForSelectorOptions().setTimeout(DEFAULT_TIMEOUT_MS));
+        if (completeProfileModal.isVisible(DEFAULT_TIMEOUT_MS / 10)) {
+            completeProfileComponent.fillCommitInfoWithRandomData();
+            completeProfileModal.waitForHidden(DEFAULT_TIMEOUT_MS);
+        }
     }
 
     /** True if the Studio login form is shown within the timeout (e.g. after sign-out). */

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/ProjectDetailPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/ProjectDetailPage.java
@@ -200,6 +200,16 @@ public class ProjectDetailPage extends BasePage {
         return new CompareGitRevisionsDialogComponent(diffTab);
     }
 
+    // The newest revision's git hash, parsed from the first History entry's data-testid
+    // ("revision-comment-<hash>"). Lets callers assert a new revision was committed (id changes).
+    public String getLatestRevisionId() {
+        openHistoryTab();
+        Locator first = revisionEntries.getLocator().first();
+        first.waitFor();
+        String testId = first.getAttribute("data-testid");
+        return testId == null ? "" : testId.substring(testId.lastIndexOf('-') + 1);
+    }
+
     public int getRevisionsCount() {
         openHistoryTab();
         // The History tab loads its revision list asynchronously after the spinner clears, so wait for

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/ProjectDetailPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/ProjectDetailPage.java
@@ -40,10 +40,14 @@ public class ProjectDetailPage extends BasePage {
     private WebElement projectStatus;       // React status: Local / Opened / Editing / Closed / ...
     // Files tab: a file tree on the left, a preview panel with per-file actions on the right
     private WebElement fileNodeByName;      // format(fileName)
-    private WebElement fileDeleteBtn;
-    private WebElement fileDeleteConfirmOk;
+    private WebElement filesAddBtn;
+    private WebElement filesAddMenuItem;
+    private WebElement fileActionsBtn;
+    private WebElement fileActionsMenuItem;
+    private WebElement fileDeleteSubmitBtn;
     private WebElement filesUploadInput;
-    private WebElement filesNewFolderBtn;
+    private WebElement filesUploadSubmitBtn;
+    private WebElement filesUploadNameField;
     private WebElement folderPathInput;
     private WebElement folderSubmitBtn;
     // History tab
@@ -81,10 +85,15 @@ public class ProjectDetailPage extends BasePage {
         revisionsCompareBtn = new WebElement(page, "[data-testid=revisions-compare]", "revisionsCompareBtn");
         revisionCompareSubmit = new WebElement(page, "[data-testid=revision-compare-submit]", "revisionCompareSubmit");
         fileNodeByName = new WebElement(page, "xpath=//div[@role='treeitem'][.//*[normalize-space()='%s']]", "fileTreeNode");
-        fileDeleteBtn = new WebElement(page, "[data-testid=file-delete]", "fileDeleteBtn");
-        fileDeleteConfirmOk = new WebElement(page, "xpath=//div[contains(@class,'ant-popover')]//button[.//span[normalize-space()='OK']]", "fileDeleteConfirmOk");
-        filesUploadInput = new WebElement(page, "[data-testid=files-upload-input]", "filesUploadInput");
-        filesNewFolderBtn = new WebElement(page, "[data-testid=files-new-folder]", "filesNewFolderBtn");
+        filesAddBtn = new WebElement(page, "[data-testid=files-add]", "filesAddBtn");
+        filesAddMenuItem = new WebElement(page, "xpath=//div[contains(@class,'ant-dropdown')][not(contains(@class,'ant-dropdown-hidden'))]//span[@data-testid='%s']", "filesAddMenuItem");
+        fileActionsBtn = new WebElement(page, "[data-testid=file-actions]", "fileActionsBtn");
+        fileActionsMenuItem = new WebElement(page, "xpath=//div[contains(@class,'ant-dropdown')][not(contains(@class,'ant-dropdown-hidden'))]//li[contains(@class,'ant-dropdown-menu-item')][normalize-space()='%s']", "fileActionsMenuItem");
+        fileDeleteSubmitBtn = new WebElement(page, "[data-testid=file-delete-submit]", "fileDeleteSubmitBtn");
+        // antd Upload.Dragger forwards unknown props to the file input itself, so the testid lands there.
+        filesUploadInput = new WebElement(page, "input[data-testid=files-upload-dragger]", "filesUploadInput");
+        filesUploadNameField = new WebElement(page, "[data-testid=files-upload-name]", "filesUploadNameField");
+        filesUploadSubmitBtn = new WebElement(page, "[data-testid=files-upload-submit]", "filesUploadSubmitBtn");
         folderPathInput = new WebElement(page, "[data-testid=files-folder-path]", "folderPathInput");
         folderSubmitBtn = new WebElement(page, "[data-testid=files-folder-submit]", "folderSubmitBtn");
         tagValueForType = new WebElement(page, "xpath=//*[@data-testid='overview-left']//span[contains(@class,'ant-tag')][./span[1][normalize-space()='%s']]/span[last()]", "tagValueForType");
@@ -269,13 +278,16 @@ public class ProjectDetailPage extends BasePage {
         return revisionEntries.getLocator().count();
     }
 
-    // Selecting a file reveals the preview panel with its delete action; deletion is confirmed via a popconfirm.
-    // The tree node is removed asynchronously after the popconfirm, so wait it out before returning — otherwise
-    // a following isFilePresent check races the removal and still sees the node.
+    /**
+     * Deletes a file: select it in the tree, then Delete from the preview pane's "More actions" menu and
+     * confirm in the delete dialog. The tree node goes away asynchronously, so wait it out — otherwise a
+     * following isFilePresent check races the removal and still sees the node.
+     */
     public ProjectDetailPage deleteFile(String fileName) {
         fileNodeByName.format(fileName).click();
-        fileDeleteBtn.click();
-        fileDeleteConfirmOk.click();
+        fileActionsBtn.click();
+        fileActionsMenuItem.format("Delete").click();
+        fileDeleteSubmitBtn.click();
         waitUntilSpinnerLoaded();
         fileNodeByName.format(fileName).waitForHidden(DEFAULT_TIMEOUT_MS);
         return this;
@@ -285,18 +297,38 @@ public class ProjectDetailPage extends BasePage {
         return fileNodeByName.format(fileName).isVisible(DEFAULT_TIMEOUT_MS);
     }
 
-    // Uploads a file into the project via the Files tab's upload input (adds/overwrites the module).
+    // Uploads a file into the project: Files tab -> Add -> Upload -> pick the file -> submit.
     public ProjectDetailPage uploadFile(String filePath) {
+        return uploadFileAs(filePath, null);
+    }
+
+    /**
+     * Uploads a file and stores it under a different name. A single-file upload exposes a Name field
+     * (pre-filled from the picked file), which is how the legacy upload dialog's source→target rename maps
+     * onto the React Files tab.
+     */
+    public ProjectDetailPage uploadFileAs(String filePath, String targetName) {
         openFilesTab();
+        openAddMenuItem("files-upload");
         filesUploadInput.setInputFiles(filePath);
+        if (targetName != null && !targetName.isEmpty()) {
+            filesUploadNameField.waitForVisible(DEFAULT_TIMEOUT_MS).fill(targetName);
+        }
+        filesUploadSubmitBtn.click();
         waitUntilSpinnerLoaded();
         return this;
+    }
+
+    // The Files tab gathers New folder / New text file / Upload behind a single Add menu.
+    private void openAddMenuItem(String itemTestId) {
+        filesAddBtn.click();
+        filesAddMenuItem.format(itemTestId).click();
     }
 
     // Creates a folder (or path/to/folder) in the project via the Files tab.
     public ProjectDetailPage createFolder(String folderPath) {
         openFilesTab();
-        filesNewFolderBtn.click();
+        openAddMenuItem("files-new-folder");
         folderPathInput.fill(folderPath);
         folderSubmitBtn.click();
         waitUntilSpinnerLoaded();

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/ProjectDetailPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/ProjectDetailPage.java
@@ -1,10 +1,14 @@
 package domain.ui.webstudio.pages.mainpages;
 
 import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
 import configuration.core.ui.WebElement;
+import configuration.driver.LocalDriverPool;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
+import domain.ui.webstudio.components.repositorytabcomponents.CompareGitRevisionsDialogComponent;
 import domain.ui.webstudio.components.repositorytabcomponents.SyncUpdatesDialogComponent;
 import domain.ui.webstudio.pages.BasePage;
+import helpers.utils.WaitUtil;
 import lombok.Getter;
 
 import java.util.ArrayList;
@@ -43,6 +47,9 @@ public class ProjectDetailPage extends BasePage {
     private WebElement folderSubmitBtn;
     // History tab
     private WebElement revisionEntries;     // one per revision (revision-comment-<hash>)
+    private WebElement revisionCompareToggles;  // per-revision "select for comparison" toggles
+    private WebElement revisionsCompareBtn;     // "Compare (n/2)" button
+    private WebElement revisionCompareSubmit;   // submit in the "Compare" modal (opens the diff tab)
     // Overview tab: assigned tags render as ant-tags "<type> → <value>" in the TAGS section
     private WebElement tagValueForType;     // format(tagType) → the value span
 
@@ -67,6 +74,9 @@ public class ProjectDetailPage extends BasePage {
         syncUpdatesDialogComponent = new SyncUpdatesDialogComponent();
         projectStatus = new WebElement(page, "[data-testid^=\"status-\"]", "projectStatus");
         revisionEntries = new WebElement(page, "xpath=//*[starts-with(@data-testid,'revision-comment-')]", "revisionEntries");
+        revisionCompareToggles = new WebElement(page, "xpath=//*[starts-with(@data-testid,'revision-compare-') and not(@data-testid='revision-compare-file') and not(@data-testid='revision-compare-submit')]", "revisionCompareToggles");
+        revisionsCompareBtn = new WebElement(page, "[data-testid=revisions-compare]", "revisionsCompareBtn");
+        revisionCompareSubmit = new WebElement(page, "[data-testid=revision-compare-submit]", "revisionCompareSubmit");
         fileNodeByName = new WebElement(page, "xpath=//div[@role='treeitem'][.//*[normalize-space()='%s']]", "fileTreeNode");
         fileDeleteBtn = new WebElement(page, "[data-testid=file-delete]", "fileDeleteBtn");
         fileDeleteConfirmOk = new WebElement(page, "xpath=//div[contains(@class,'ant-popover')]//button[.//span[normalize-space()='OK']]", "fileDeleteConfirmOk");
@@ -164,6 +174,30 @@ public class ProjectDetailPage extends BasePage {
             descriptions.add(entries.nth(i).textContent().trim());
         }
         return descriptions;
+    }
+
+    // Opens the repository revision comparison: selects the two newest revisions on the History tab, submits
+    // the Compare dialog (which opens the diff in a NEW browser tab, the legacy showDiff.xhtml JSF page), and
+    // returns a CompareGitRevisionsDialogComponent bound to that tab.
+    public CompareGitRevisionsDialogComponent openRevisionCompare() {
+        openHistoryTab();
+        Locator toggles = revisionCompareToggles.getLocator();
+        toggles.first().waitFor();
+        toggles.nth(0).click();
+        toggles.nth(1).click();
+        revisionsCompareBtn.click();
+        revisionCompareSubmit.waitForVisible(DEFAULT_TIMEOUT_MS);
+        int pagesBefore = LocalDriverPool.getBrowserContext().pages().size();
+        revisionCompareSubmit.click();
+        WaitUtil.waitForCondition(
+                () -> LocalDriverPool.getBrowserContext().pages().size() > pagesBefore,
+                DEFAULT_TIMEOUT_MS, 250, "Waiting for the compare diff tab to open");
+        List<Page> pages = LocalDriverPool.getBrowserContext().pages();
+        Page diffTab = pages.get(pages.size() - 1);
+        WaitUtil.waitForCondition(() -> diffTab.url().contains("showDiff"),
+                DEFAULT_TIMEOUT_MS, 250, "Waiting for the diff tab to load showDiff.xhtml");
+        diffTab.waitForLoadState();
+        return new CompareGitRevisionsDialogComponent(diffTab);
     }
 
     public int getRevisionsCount() {

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/ProjectDetailPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/ProjectDetailPage.java
@@ -34,6 +34,7 @@ public class ProjectDetailPage extends BasePage {
     private WebElement branchSwitchAfterToggle;  // ant-switch "Switch to the new branch" (role=switch)
     private WebElement branchRowByName;          // format(name) → branch-commit-<name> (row presence)
     private WebElement branchMergeByName;        // format(name) → branch-merge-<name>
+    private WebElement branchCreateErrorNotice;  // React ant-notification shown when a branch create fails
     private SyncUpdatesDialogComponent syncUpdatesDialogComponent;
     // Header
     private WebElement projectStatus;       // React status: Local / Opened / Editing / Closed / ...
@@ -71,6 +72,7 @@ public class ProjectDetailPage extends BasePage {
         branchSwitchAfterToggle = new WebElement(page, "[data-testid=branches-switch-after]", "branchSwitchAfterToggle");
         branchRowByName = new WebElement(page, "xpath=//*[@data-testid='branch-commit-%s']", "branchRow");
         branchMergeByName = new WebElement(page, "xpath=//*[@data-testid='branch-merge-%s']", "branchMergeBtn");
+        branchCreateErrorNotice = new WebElement(page, "xpath=//div[contains(@class,'ant-notification')]//div[@role='alert']", "branchCreateErrorNotice");
         syncUpdatesDialogComponent = new SyncUpdatesDialogComponent();
         projectStatus = new WebElement(page, "[data-testid^=\"status-\"]", "projectStatus");
         revisionEntries = new WebElement(page, "xpath=//*[starts-with(@data-testid,'revision-comment-')]", "revisionEntries");
@@ -129,6 +131,17 @@ public class ProjectDetailPage extends BasePage {
         branchCreateSubmitBtn.click();
         waitUntilSpinnerLoaded();
         return this;
+    }
+
+    // Attempts to create a branch whose name is expected to be rejected (e.g. it already exists in the
+    // repository). Returns the React error notification text (e.g. "Branch 'x' already exists in repository.").
+    public String createBranchExpectingError(String branchName) {
+        openBranchesTab();
+        branchesCreateBtn.click();
+        branchNewNameField.fill(branchName);
+        branchCreateSubmitBtn.click();
+        branchCreateErrorNotice.waitForVisible(DEFAULT_TIMEOUT_MS);
+        return branchCreateErrorNotice.getText().trim();
     }
 
     public boolean isBranchPresent(String branchName) {

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/ProjectDetailPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/ProjectDetailPage.java
@@ -53,6 +53,7 @@ public class ProjectDetailPage extends BasePage {
     private WebElement revisionCompareSubmit;   // submit in the "Compare" modal (opens the diff tab)
     // Overview tab: assigned tags render as ant-tags "<type> → <value>" in the TAGS section
     private WebElement tagValueForType;     // format(tagType) → the value span
+    private WebElement overviewRight;       // the right column of the Overview tab (Status/Repository/Path/Branch/Revision/Last change/Comment)
 
     public ProjectDetailPage() {
         super();
@@ -87,6 +88,7 @@ public class ProjectDetailPage extends BasePage {
         folderPathInput = new WebElement(page, "[data-testid=files-folder-path]", "folderPathInput");
         folderSubmitBtn = new WebElement(page, "[data-testid=files-folder-submit]", "folderSubmitBtn");
         tagValueForType = new WebElement(page, "xpath=//*[@data-testid='overview-left']//span[contains(@class,'ant-tag')][./span[1][normalize-space()='%s']]/span[last()]", "tagValueForType");
+        overviewRight = new WebElement(page, "[data-testid=overview-right]", "overviewRight");
     }
 
     public ProjectDetailPage openOverviewTab() {
@@ -173,6 +175,31 @@ public class ProjectDetailPage extends BasePage {
     // "No Changes" / "In Editing" wording, so migrated tests must assert against the React values.
     public String getStatus() {
         return projectStatus.getText().trim();
+    }
+
+    // The React Overview-right column concatenates its labelled fields into one text blob
+    // ("...Revision<hash>Last change<author><date>Comment<text>"). Extracts the value between two labels.
+    private String extractOverviewField(String label, String nextLabel) {
+        openOverviewTab();
+        String blob = overviewRight.getText();
+        int start = blob.indexOf(label);
+        if (start < 0) {
+            return "";
+        }
+        start += label.length();
+        int end = blob.indexOf(nextLabel, start);
+        return (end < 0 ? blob.substring(start) : blob.substring(start, end)).trim();
+    }
+
+    // Replaces the legacy Properties-tab getRevision() — the React Overview shows the FULL commit hash.
+    public String getOverviewRevision() {
+        return extractOverviewField("Revision", "Last change");
+    }
+
+    // Replaces the legacy Properties-tab getModifiedBy()+getModifiedAt() — the React Overview combines the
+    // author and timestamp into a single "Last change" field (e.g. "Sheldon SawaynJul 16, 2026 6:04 PM").
+    public String getOverviewLastChange() {
+        return extractOverviewField("Last change", "Comment");
     }
 
     // Revision comments on the History tab (each revision-comment-<hash>), newest first. Replaces the

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/ProjectDetailPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/ProjectDetailPage.java
@@ -202,6 +202,16 @@ public class ProjectDetailPage extends BasePage {
         return extractOverviewField("Last change", "Comment");
     }
 
+    // Replaces the legacy Properties-tab getPath() — the project's path-in-repository from the Overview.
+    public String getOverviewPath() {
+        return extractOverviewField("Path", "Branch");
+    }
+
+    // Replaces the legacy Properties-tab getRepository() — the design repository name from the Overview.
+    public String getOverviewRepository() {
+        return extractOverviewField("Repository", "Path");
+    }
+
     // Revision comments on the History tab (each revision-comment-<hash>), newest first. Replaces the
     // legacy RepositoryContentRevisionsTabComponent.getRevisionDescription(i) loop.
     public List<String> getRevisionDescriptions() {

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
@@ -248,6 +248,11 @@ public class RepositoryPage extends BasePage {
         return deployModalComponent.waitForModal();
     }
 
+    // Whether the project row exposes the Deploy action (ACL: needs >= Viewer on design + Edit on deploy repo).
+    public boolean isDeployAvailable(String projectName) {
+        return projectDeployAction.format(projectName).isVisible(DEFAULT_TIMEOUT_MS);
+    }
+
     public void closeProject(String projectName) {
         projectActionByName.format(projectName, "Close").click();
         // Closing a project with uncommitted local changes prompts a "Discard unsaved changes?" confirm.

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
@@ -76,6 +76,7 @@ public class RepositoryPage extends BasePage {
     private AddFolderDialogComponent addFolderDialogComponent;
     private ProjectDeleteConfirmModalComponent projectDeleteConfirmModalComponent;
     private SaveProjectDialogComponent saveProjectDialogComponent;
+    private WebElement projectDeployAction;
 
     public RepositoryPage() {
         super();
@@ -87,6 +88,7 @@ public class RepositoryPage extends BasePage {
         refreshBtn = new WebElement(page, "xpath=//a[@id='designRepoRefresh']", "refreshBtn");
         projectRowByName = new WebElement(page, "xpath=//tr[starts-with(@data-testid,'project-row')][.//span[normalize-space()='%s']]", "projectRow");
         projectActionByName = new WebElement(page, "xpath=//tr[starts-with(@data-testid,'project-row')][.//span[normalize-space()='%s']]//button[@aria-label='%s']", "projectRowAction");
+        projectDeployAction = new WebElement(page, "xpath=//tr[starts-with(@data-testid,'project-row')][.//span[normalize-space()='%s']]//button[starts-with(@data-testid,'project-action-deploy-')]", "projectDeployAction");
         discardCloseConfirmBtn = new WebElement(page, "[data-testid=discard-close-confirm]", "discardCloseConfirmBtn");
         copyProjectNameField = new WebElement(page, "[data-testid=copy-project-name]", "copyProjectNameField");
         copyProjectSubmitBtn = new WebElement(page, "[data-testid=copy-project-submit]", "copyProjectSubmitBtn");
@@ -236,6 +238,14 @@ public class RepositoryPage extends BasePage {
     // Opened projects expose "Close"; closed ones expose "Open".
     public void openProject(String projectName) {
         projectActionByName.format(projectName, "Open").click();
+    }
+
+    // Opens the React DeployModal via the project row's Deploy action (rocket icon, testid
+    // project-action-deploy-<id>) — only present when a deployment/production repository is configured.
+    // Replaces the legacy RepositoryContentButtonsPanelComponent.clickDeploy.
+    public DeployModalComponent clickDeploy(String projectName) {
+        projectDeployAction.format(projectName).click();
+        return deployModalComponent.waitForModal();
     }
 
     public void closeProject(String projectName) {

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
@@ -93,7 +93,7 @@ public class RepositoryPage extends BasePage {
         copyProjectNameField = new WebElement(page, "[data-testid=copy-project-name]", "copyProjectNameField");
         copyProjectSubmitBtn = new WebElement(page, "[data-testid=copy-project-submit]", "copyProjectSubmitBtn");
 
-        filterByNameInput = new WebElement(page, "xpath=//input[@id='nameFilter']", "filterByNameInput");
+        filterByNameInput = new WebElement(page, "[data-testid=projects-search]", "filterByNameInput");
         clearFilterBtn = new WebElement(page, "xpath=//span[@id='clearFilter']", "clearFilterBtn");
         advancedFilterBtn = new WebElement(page, "xpath=//a[@id='filterButton']", "advancedFilterBtn");
         hideDeletedCheckbox = new WebElement(page, "xpath=//input[@id='filterForm:hideDeleted']", "hideDeletedCheckbox");
@@ -378,6 +378,10 @@ public class RepositoryPage extends BasePage {
         WaitUtil.waitForCondition(() -> rows.count() > 0, 5000, 250, "Waiting for projects to load");
         int count = rows.count();
         for (int i = 0; i < count; i++) {
+            // Only count rows that are actually visible — the React name filter hides non-matching rows.
+            if (!rows.nth(i).isVisible()) {
+                continue;
+            }
             String name = rows.nth(i).locator("span").first().textContent();
             if (name != null && !name.trim().isEmpty()) {
                 projectNames.add(name.trim());
@@ -424,13 +428,18 @@ public class RepositoryPage extends BasePage {
     }
 
     public void filterByName(String name) {
-        filterByNameInput.fillSequentially(name);
-        WaitUtil.sleep(300, "Waiting for client-side filter to apply");
+        // React projects-search is a plain <input> that filters the list on value change; a single fill()
+        // (not per-char fillSequentially) reliably drives its onChange.
+        filterByNameInput.click();
+        filterByNameInput.fill(name);
+        WaitUtil.sleep(800, "Waiting for the React client-side name filter to apply");
     }
 
     public void clearNameFilter() {
-        clearFilterBtn.click();
-        WaitUtil.sleep(300, "Waiting for filter to clear");
+        // fill("") fires the React onChange (a bare clear() may not), restoring the full list.
+        filterByNameInput.click();
+        filterByNameInput.fill("");
+        WaitUtil.sleep(800, "Waiting for the filter to clear and the full list to restore");
     }
 
     public void setShowDeletedProjects(boolean showDeleted) {

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
@@ -31,10 +31,17 @@ public class RepositoryPage extends BasePage {
     // top menu elements:
     private WebElement refreshBtn;
     private WebElement createProjectLink;
+    // Inline row buttons render with the row itself, so a short probe decides inline-vs-overflow.
+    private static final int ROW_ACTION_PROBE_MS = DEFAULT_TIMEOUT_MS / 5;
+    // aria-label of the row's overflow trigger — a menu opener, not an action of its own.
+    private static final String OVERFLOW_TRIGGER_LABEL = "Actions";
+
     // React projects list (build 032c60a664ce+): rows are <tr data-testid=project-row-...> with
     // per-row action buttons keyed by aria-label. Format placeholders with the project name.
     private WebElement projectRowByName;
     private WebElement projectActionByName;
+    private WebElement projectRowMoreBtn;
+    private WebElement overflowMenuItem;
     private WebElement discardCloseConfirmBtn;
     private WebElement copyProjectNameField;
     private WebElement copyProjectSubmitBtn;
@@ -89,6 +96,8 @@ public class RepositoryPage extends BasePage {
         projectRowByName = new WebElement(page, "xpath=//tr[starts-with(@data-testid,'project-row')][.//span[normalize-space()='%s']]", "projectRow");
         projectActionByName = new WebElement(page, "xpath=//tr[starts-with(@data-testid,'project-row')][.//span[normalize-space()='%s']]//button[@aria-label='%s']", "projectRowAction");
         projectDeployAction = new WebElement(page, "xpath=//tr[starts-with(@data-testid,'project-row')][.//span[normalize-space()='%s']]//button[starts-with(@data-testid,'project-action-deploy-')]", "projectDeployAction");
+        projectRowMoreBtn = new WebElement(page, "xpath=//tr[starts-with(@data-testid,'project-row')][.//span[normalize-space()='%s']]//button[starts-with(@data-testid,'project-actions-')]", "projectRowMoreBtn");
+        overflowMenuItem = new WebElement(page, "xpath=//div[contains(@class,'ant-dropdown')][not(contains(@class,'ant-dropdown-hidden'))]//li[contains(@class,'ant-dropdown-menu-item')][normalize-space()='%s']", "overflowMenuItem");
         discardCloseConfirmBtn = new WebElement(page, "[data-testid=discard-close-confirm]", "discardCloseConfirmBtn");
         copyProjectNameField = new WebElement(page, "[data-testid=copy-project-name]", "copyProjectNameField");
         copyProjectSubmitBtn = new WebElement(page, "[data-testid=copy-project-submit]", "copyProjectSubmitBtn");
@@ -170,7 +179,7 @@ public class RepositoryPage extends BasePage {
     // The React repository leaves a freshly created project CLOSED (the legacy UI opened it on create),
     // so the editor workspace stays empty. Open it into the workspace so callers can select its modules.
     private void openIfClosed(String projectName) {
-        if (projectActionByName.format(projectName, "Open").isVisible(3000)) {
+        if (isProjectActionAvailable(projectName, "Open")) {
             openProject(projectName);
             waitUntilSpinnerLoaded();
         }
@@ -209,14 +218,29 @@ public class RepositoryPage extends BasePage {
         return projectRowByName.format(projectName).isVisible(DEFAULT_TIMEOUT_MS);
     }
 
+    /**
+     * Clicks a row action by its label, wherever the row keeps it. Studio 6.4.0 shows only
+     * Copy / Delete Branch / Open / Close as buttons and folds Save, Open Revision, Sync, Deploy,
+     * Compare, Export and Delete into the row's overflow menu.
+     */
+    public void clickRowAction(String projectName, String actionLabel) {
+        WebElement inlineAction = projectActionByName.format(projectName, actionLabel);
+        if (inlineAction.isVisible(ROW_ACTION_PROBE_MS)) {
+            inlineAction.click();
+            return;
+        }
+        projectRowMoreBtn.format(projectName).click();
+        overflowMenuItem.format(actionLabel).click();
+    }
+
     // A closed project exposes the "Open" row action; an opened one exposes "Close".
     public boolean isProjectActionAvailable(String projectName, String actionLabel) {
-        return projectActionByName.format(projectName, actionLabel).isVisible(DEFAULT_TIMEOUT_MS);
+        return getProjectActionLabels(projectName).contains(actionLabel);
     }
 
     // Clicks the row's Delete action and returns the (already React) confirm modal, ready to fill.
     public ProjectDeleteConfirmModalComponent deleteProject(String projectName) {
-        projectActionByName.format(projectName, "Delete").click();
+        clickRowAction(projectName, "Delete");
         return projectDeleteConfirmModalComponent.waitForVisible();
     }
 
@@ -267,24 +291,24 @@ public class RepositoryPage extends BasePage {
 
     // Opened projects expose "Close"; closed ones expose "Open".
     public void openProject(String projectName) {
-        projectActionByName.format(projectName, "Open").click();
+        clickRowAction(projectName, "Open");
     }
 
     // Opens the React DeployModal via the project row's Deploy action (rocket icon, testid
     // project-action-deploy-<id>) — only present when a deployment/production repository is configured.
     // Replaces the legacy RepositoryContentButtonsPanelComponent.clickDeploy.
     public DeployModalComponent clickDeploy(String projectName) {
-        projectDeployAction.format(projectName).click();
+        clickRowAction(projectName, "Deploy");
         return deployModalComponent.waitForModal();
     }
 
     // Whether the project row exposes the Deploy action (ACL: needs >= Viewer on design + Edit on deploy repo).
     public boolean isDeployAvailable(String projectName) {
-        return projectDeployAction.format(projectName).isVisible(DEFAULT_TIMEOUT_MS);
+        return isProjectActionAvailable(projectName, "Deploy");
     }
 
     public void closeProject(String projectName) {
-        projectActionByName.format(projectName, "Close").click();
+        clickRowAction(projectName, "Close");
         // Closing a project with uncommitted local changes prompts a "Discard unsaved changes?" confirm.
         if (discardCloseConfirmBtn.isVisible(3000)) {
             discardCloseConfirmBtn.click();
@@ -295,7 +319,7 @@ public class RepositoryPage extends BasePage {
     // Opens the React copy dialog via the row "Copy" action and returns it for full control
     // (repository / path / name), for multi-repo copy flows. Use when the name is unique in the list.
     public CopyProjectDialogComponent clickCopyAction(String projectName) {
-        projectActionByName.format(projectName, "Copy").click();
+        clickRowAction(projectName, "Copy");
         return copyProjectDialogComponent.waitForDialogToAppear();
     }
 
@@ -325,11 +349,18 @@ public class RepositoryPage extends BasePage {
         return copyProjectDialogComponent.waitForDialogToAppear();
     }
 
-    // Copy an OPENED project via the row "Copy" action → dialog (name pre-filled "<name> (Copy)") → Copy.
-    // The project must be open (copying a closed project fails with "Failed to copy the project").
+    // Copy a project into a NEW project via the row "Copy" action. On a branching repository the dialog
+    // opens in branch mode, so switch it to new-project mode before naming the copy.
     public void copyProject(String projectName, String newProjectName) {
-        projectActionByName.format(projectName, "Copy").click();
-        copyProjectNameField.fill(newProjectName);
+        clickCopyAction(projectName).setAsNewProject().setNewProjectName(newProjectName);
+        copyProjectSubmitBtn.click();
+        fillCommitInfo();
+        waitUntilSpinnerLoaded();
+    }
+
+    // Copy a project into a NEW BRANCH (the copy dialog's default mode on a git repository).
+    public void copyProjectToBranch(String projectName, String branchName) {
+        clickCopyAction(projectName).setBranchName(branchName);
         copyProjectSubmitBtn.click();
         fillCommitInfo();
         waitUntilSpinnerLoaded();
@@ -339,7 +370,7 @@ public class RepositoryPage extends BasePage {
     // (the Save action only appears while the project has local changes). Replaces the legacy
     // buttons-panel Save + SaveChangesComponent flow.
     public void saveProject(String projectName, String comment) {
-        projectActionByName.format(projectName, "Save").click();
+        clickRowAction(projectName, "Save");
         saveProjectDialogComponent.waitForVisible().setComment(comment).submit();
         waitUntilSpinnerLoaded();
     }
@@ -347,7 +378,7 @@ public class RepositoryPage extends BasePage {
     // Like saveProject, but also handles the "Configure Git Commit Info" modal raised on a user's FIRST commit
     // (the save dialog stays open behind it until the identity is filled).
     public void saveProjectWithCommitInfo(String projectName, String comment) {
-        projectActionByName.format(projectName, "Save").click();
+        clickRowAction(projectName, "Save");
         saveProjectDialogComponent.waitForVisible().setComment(comment).clickSubmit();
         fillCommitInfo();
         saveProjectDialogComponent.waitForSubmitHidden();
@@ -554,7 +585,11 @@ public class RepositoryPage extends BasePage {
         return inlineMessage.getText().trim();
     }
 
-    // React row-action aria-labels for a project's row (Open/Close/Copy/Export/Delete/Deploy/...).
+    /**
+     * Every action a project's row offers (Open/Close/Copy/Export/Delete/Deploy/...), taking both the
+     * inline buttons and the overflow menu into account — 6.4.0 keeps most actions behind the menu, so
+     * the inline buttons alone are not the project's permission set.
+     */
     public List<String> getProjectActionLabels(String projectName) {
         List<String> labels = new ArrayList<>();
         Locator btns = page.locator(String.format(
@@ -564,9 +599,18 @@ public class RepositoryPage extends BasePage {
         int count = btns.count();
         for (int i = 0; i < count; i++) {
             String label = btns.nth(i).getAttribute("aria-label");
-            if (label != null && !label.isEmpty()) {
+            if (label != null && !label.isEmpty() && !OVERFLOW_TRIGGER_LABEL.equals(label)) {
                 labels.add(label);
             }
+        }
+        if (projectRowMoreBtn.format(projectName).isVisible(ROW_ACTION_PROBE_MS)) {
+            projectRowMoreBtn.format(projectName).click();
+            Locator items = page.locator(
+                    "xpath=//div[contains(@class,'ant-dropdown')][not(contains(@class,'ant-dropdown-hidden'))]"
+                            + "//li[contains(@class,'ant-dropdown-menu-item')]");
+            WaitUtil.waitForCondition(() -> items.count() > 0, DEFAULT_TIMEOUT_MS, 250, "Waiting for the row overflow menu");
+            labels.addAll(items.allInnerTexts().stream().map(String::trim).filter(text -> !text.isEmpty()).toList());
+            page.keyboard().press("Escape");
         }
         return labels;
     }

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
@@ -490,6 +490,23 @@ public class RepositoryPage extends BasePage {
         return inlineMessage.getText().trim();
     }
 
+    // React row-action aria-labels for a project's row (Open/Close/Copy/Export/Delete/Deploy/...).
+    public List<String> getProjectActionLabels(String projectName) {
+        List<String> labels = new ArrayList<>();
+        Locator btns = page.locator(String.format(
+                "xpath=//tr[starts-with(@data-testid,'project-row')][.//span[normalize-space()='%s']]//button[@aria-label]",
+                projectName));
+        WaitUtil.waitForCondition(() -> btns.count() > 0, DEFAULT_TIMEOUT_MS, 250, "Waiting for project row actions");
+        int count = btns.count();
+        for (int i = 0; i < count; i++) {
+            String label = btns.nth(i).getAttribute("aria-label");
+            if (label != null && !label.isEmpty()) {
+                labels.add(label);
+            }
+        }
+        return labels;
+    }
+
     public List<String> getTableActionTitles(String projectName) {
         List<String> titles = new ArrayList<>();
         int rowIndex = findProjectRowIndex(projectName);

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
@@ -226,6 +226,14 @@ public class RepositoryPage extends BasePage {
         return new ProjectDetailPage();
     }
 
+    // React has no status column in the projects table — status lives in the project detail. This reads it
+    // and returns to the list so callers can keep using row actions. (Legacy getProjectStatusFromTable.)
+    public String getProjectStatusFromDetail(String projectName) {
+        String status = openProjectDetail(projectName).getStatus();
+        openProjectsList();
+        return status;
+    }
+
     // Return to the projects list from a project-detail view (the detail has no row actions), so callers
     // can chain list operations (open/close/delete) after inspecting a project's detail.
     public RepositoryPage openProjectsList() {
@@ -278,6 +286,16 @@ public class RepositoryPage extends BasePage {
     public void saveProject(String projectName, String comment) {
         projectActionByName.format(projectName, "Save").click();
         saveProjectDialogComponent.waitForVisible().setComment(comment).submit();
+        waitUntilSpinnerLoaded();
+    }
+
+    // Like saveProject, but also handles the "Configure Git Commit Info" modal raised on a user's FIRST commit
+    // (the save dialog stays open behind it until the identity is filled).
+    public void saveProjectWithCommitInfo(String projectName, String comment) {
+        projectActionByName.format(projectName, "Save").click();
+        saveProjectDialogComponent.waitForVisible().setComment(comment).clickSubmit();
+        fillCommitInfo();
+        saveProjectDialogComponent.waitForSubmitHidden();
         waitUntilSpinnerLoaded();
     }
 

--- a/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
+++ b/src/main/java/domain/ui/webstudio/pages/mainpages/RepositoryPage.java
@@ -226,6 +226,28 @@ public class RepositoryPage extends BasePage {
         return new ProjectDetailPage();
     }
 
+    // When two rows share a name (e.g. the same project name copied across repositories), disambiguate by
+    // state: the OPEN row exposes a "Close" action, the CLOSED row exposes an "Open" action. Opens that row's
+    // detail. Replaces the legacy tree's selectOpened/ClosedItemInFolder.
+    public ProjectDetailPage openProjectDetailByState(String projectName, boolean opened) {
+        String action = opened ? "Close" : "Open";
+        page.locator(String.format(
+                "xpath=//tr[starts-with(@data-testid,'project-row')][.//span[normalize-space()='%s']][.//button[@aria-label='%s']]",
+                projectName, action)).first().click();
+        return new ProjectDetailPage();
+    }
+
+    // The React projects list is repo-filtered via checkboxes in the filter rail (filter-repo-<name>, lowercase).
+    // Ensures the given repository's projects are shown (checks the box only if not already checked).
+    public void ensureRepoFilterChecked(String repositoryNameLower) {
+        WebElement checkbox = new WebElement(page, "[data-testid=filter-repo-" + repositoryNameLower + "]",
+                "repoFilter-" + repositoryNameLower);
+        if (checkbox.isVisible(3000) && !checkbox.isChecked()) {
+            checkbox.click();
+            waitUntilSpinnerLoaded();
+        }
+    }
+
     // React has no status column in the projects table — status lives in the project detail. This reads it
     // and returns to the list so callers can keep using row actions. (Legacy getProjectStatusFromTable.)
     public String getProjectStatusFromDetail(String projectName) {
@@ -268,6 +290,39 @@ public class RepositoryPage extends BasePage {
             discardCloseConfirmBtn.click();
         }
         waitUntilSpinnerLoaded();
+    }
+
+    // Opens the React copy dialog via the row "Copy" action and returns it for full control
+    // (repository / path / name), for multi-repo copy flows. Use when the name is unique in the list.
+    public CopyProjectDialogComponent clickCopyAction(String projectName) {
+        projectActionByName.format(projectName, "Copy").click();
+        return copyProjectDialogComponent.waitForDialogToAppear();
+    }
+
+    // Click the Open/Close action on a same-name row disambiguated by state (opened row has "Close", closed "Open").
+    public void openProjectByState(String projectName, boolean opened) {
+        String stateAction = opened ? "Close" : "Open";
+        page.locator(String.format(
+                "xpath=//tr[starts-with(@data-testid,'project-row')][.//span[normalize-space()='%s']][.//button[@aria-label='%s']]//button[@aria-label='Open']",
+                projectName, stateAction)).first().click();
+    }
+
+    // Delete a same-name project disambiguated by state; returns the (React) confirm modal.
+    public ProjectDeleteConfirmModalComponent deleteProjectByState(String projectName, boolean opened) {
+        String stateAction = opened ? "Close" : "Open";
+        page.locator(String.format(
+                "xpath=//tr[starts-with(@data-testid,'project-row')][.//span[normalize-space()='%s']][.//button[@aria-label='%s']]//button[@aria-label='Delete']",
+                projectName, stateAction)).first().click();
+        return projectDeleteConfirmModalComponent.waitForVisible();
+    }
+
+    // Same, but disambiguates when two rows share a name: opened row exposes "Close", closed row "Open".
+    public CopyProjectDialogComponent clickCopyActionByState(String projectName, boolean opened) {
+        String stateAction = opened ? "Close" : "Open";
+        page.locator(String.format(
+                "xpath=//tr[starts-with(@data-testid,'project-row')][.//span[normalize-space()='%s']][.//button[@aria-label='%s']]//button[@aria-label='Copy']",
+                projectName, stateAction)).first().click();
+        return copyProjectDialogComponent.waitForDialogToAppear();
     }
 
     // Copy an OPENED project via the row "Copy" action → dialog (name pre-filled "<name> (Copy)") → Copy.

--- a/src/test/java/tests/ui/webstudio/git/TestGitCopyProjectIntoExistingBranchViaEditorTab.java
+++ b/src/test/java/tests/ui/webstudio/git/TestGitCopyProjectIntoExistingBranchViaEditorTab.java
@@ -8,8 +8,8 @@ import configuration.driver.LocalDriverPool;
 import domain.serviceclasses.constants.User;
 import domain.ui.webstudio.components.common.CreateNewProjectComponent;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
-import domain.ui.webstudio.components.repositorytabcomponents.CopyProjectDialogComponent;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
+import domain.ui.webstudio.pages.mainpages.ProjectDetailPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
 import helpers.service.LoginService;
 import helpers.service.UserService;
@@ -23,7 +23,8 @@ public class TestGitCopyProjectIntoExistingBranchViaEditorTab extends BaseTest {
     private static final String PROJECT_NAME = "TestProject";
     private static final String SECOND_PROJECT_NAME = "TestProject2";
     private static final String BRANCH_NAME = "myBranch";
-    private static final String EXPECTED_ERROR_MESSAGE = "Branch myBranch already exists in repository.";
+    // React surfaces the collision as an ant-notification: "Branch 'myBranch' already exists in repository."
+    private static final String EXPECTED_ERROR_MESSAGE = "Branch '" + BRANCH_NAME + "' already exists in repository.";
 
     @Test
     @TestCaseId("EPBDS-8495")
@@ -32,51 +33,29 @@ public class TestGitCopyProjectIntoExistingBranchViaEditorTab extends BaseTest {
     public void testGitCopyProjectIntoExistingBranchEditorTab() {
         LoginService loginService = new LoginService(LocalDriverPool.getPage());
         EditorPage editorPage = loginService.login(UserService.getUser(User.ADMIN));
-        RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.REPOSITORY);
+        RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
+                .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
 
-        // Create first project
+        // Create two projects
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, PROJECT_NAME, "Sample Project");
-        repositoryPage.refresh();
+        repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, SECOND_PROJECT_NAME, "Sample Project");
 
-        // Navigate to Editor and copy project with custom branch
-        editorPage = repositoryPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
-        editorPage.getEditorLeftProjectModuleSelectorComponent().selectProject(PROJECT_NAME);
-        editorPage.getEditorToolbarPanelComponent().clickCopyProjectBtn();
+        // React: "copy a project into a new branch" is the project-detail Branches tab "New branch" action.
+        // Create the branch and switch onto it, then verify the project's current branch is the new one
+        // (EPBDS-10629 — the working branch follows the copy).
+        ProjectDetailPage detail = repositoryPage.openProjectDetail(PROJECT_NAME);
+        detail.createBranch(BRANCH_NAME, true);
+        assertThat(detail.getCurrentBranch())
+                .as("Current branch should be set to the newly created branch")
+                .isEqualTo(BRANCH_NAME);
 
-        CopyProjectDialogComponent copyDialog = repositoryPage.getCopyProjectDialogComponent();
-        copyDialog.waitForDialogToAppear();
-        copyDialog.setNewBranchName(BRANCH_NAME);
-        copyDialog.clickCopyButton();
+        // Creating the same branch name for the second project must be rejected — branches are repo-wide.
+        String error = repositoryPage.openProjectsList()
+                .openProjectDetail(SECOND_PROJECT_NAME)
+                .createBranchExpectingError(BRANCH_NAME);
 
-        // Verify branch value in next copy operation (EPBDS-10629, second part)
-        repositoryPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_NAME);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickCopyBtn();
-
-        copyDialog = repositoryPage.getCopyProjectDialogComponent();
-        copyDialog.waitForDialogToAppear();
-        assertThat(copyDialog.getCurrentBranch()).as("Current branch should be set to myBranch").isEqualTo(BRANCH_NAME);
-        copyDialog.clickCancelButton();
-
-        // Create second project
-        repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, SECOND_PROJECT_NAME, "Empty Project");
-        repositoryPage.refresh();
-
-        // Navigate to Editor and try to copy second project to existing branch
-        editorPage = repositoryPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
-        editorPage.getEditorLeftProjectModuleSelectorComponent().selectProject(SECOND_PROJECT_NAME);
-        editorPage.getEditorToolbarPanelComponent().clickCopyProjectBtn();
-
-        copyDialog = repositoryPage.getCopyProjectDialogComponent();
-        copyDialog.waitForDialogToAppear();
-        copyDialog.setNewBranchName(BRANCH_NAME);
-        copyDialog.clickCopyButton(false);
-
-        // Verify error message is displayed
-        assertThat(copyDialog.waitForErrors(5000))
+        assertThat(error)
                 .as("Error message about existing branch should be displayed")
-                .anyMatch(msg -> msg.contains(EXPECTED_ERROR_MESSAGE));
+                .contains(EXPECTED_ERROR_MESSAGE);
     }
 }

--- a/src/test/java/tests/ui/webstudio/git/TestGitCopyProjectIntoExistingBranchViaRepositoryTab.java
+++ b/src/test/java/tests/ui/webstudio/git/TestGitCopyProjectIntoExistingBranchViaRepositoryTab.java
@@ -8,7 +8,6 @@ import configuration.driver.LocalDriverPool;
 import domain.serviceclasses.constants.User;
 import domain.ui.webstudio.components.common.CreateNewProjectComponent;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
-import domain.ui.webstudio.components.repositorytabcomponents.CopyProjectDialogComponent;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
 import helpers.service.LoginService;
@@ -23,7 +22,8 @@ public class TestGitCopyProjectIntoExistingBranchViaRepositoryTab extends BaseTe
     private static final String PROJECT_NAME = "TestProject";
     private static final String SECOND_PROJECT_NAME = "TestProject2";
     private static final String BRANCH_NAME = "myBranch";
-    private static final String EXPECTED_ERROR_MESSAGE = "Branch myBranch already exists in repository.";
+    // React surfaces the collision as an ant-notification: "Branch 'myBranch' already exists in repository."
+    private static final String EXPECTED_ERROR_MESSAGE = "Branch '" + BRANCH_NAME + "' already exists in repository.";
 
     @Test
     @TestCaseId("EPBDS-8495")
@@ -32,40 +32,24 @@ public class TestGitCopyProjectIntoExistingBranchViaRepositoryTab extends BaseTe
     public void testGitCopyProjectIntoExistingBranchRepositoryTab() {
         LoginService loginService = new LoginService(LocalDriverPool.getPage());
         EditorPage editorPage = loginService.login(UserService.getUser(User.ADMIN));
-        RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.REPOSITORY);
+        RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
+                .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
 
-        // Create first project and copy it to a new branch
+        // Create two projects
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, PROJECT_NAME, "Sample Project");
-        repositoryPage.refresh();
+        repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, SECOND_PROJECT_NAME, "Sample Project");
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_NAME);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickCopyBtn();
+        // React: "copy a project into a new branch" is now the project-detail Branches tab "New branch" action
+        // (mirrors the legacy CopyProjectDialogComponent.setNewBranchName flow). Create the branch on the first project.
+        repositoryPage.openProjectDetail(PROJECT_NAME).createBranch(BRANCH_NAME);
 
-        CopyProjectDialogComponent copyDialog = repositoryPage.getCopyProjectDialogComponent();
-        copyDialog.waitForDialogToAppear();
-        copyDialog.setNewBranchName(BRANCH_NAME);
-        copyDialog.clickCopyButton();
-        repositoryPage.refresh();
+        // Creating the same branch name for the second project must be rejected — branches are repo-wide.
+        String error = repositoryPage.openProjectsList()
+                .openProjectDetail(SECOND_PROJECT_NAME)
+                .createBranchExpectingError(BRANCH_NAME);
 
-        // Create second project and try to copy it to the same branch
-        repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, SECOND_PROJECT_NAME, "Empty Project");
-        repositoryPage.refresh();
-
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", SECOND_PROJECT_NAME);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickCopyBtn();
-
-        copyDialog = repositoryPage.getCopyProjectDialogComponent();
-        copyDialog.waitForDialogToAppear();
-        copyDialog.setNewBranchName(BRANCH_NAME);
-        copyDialog.clickCopyButton(false);
-
-        // Verify error message is displayed
-        assertThat(copyDialog.waitForErrors(5000))
+        assertThat(error)
                 .as("Error message about existing branch should be displayed")
-                .anyMatch(msg -> msg.contains(EXPECTED_ERROR_MESSAGE));
+                .contains(EXPECTED_ERROR_MESSAGE);
     }
 }

--- a/src/test/java/tests/ui/webstudio/git/TestProtectedBranchBypassBothProtectedUi.java
+++ b/src/test/java/tests/ui/webstudio/git/TestProtectedBranchBypassBothProtectedUi.java
@@ -52,17 +52,18 @@ public class TestProtectedBranchBypassBothProtectedUi extends BaseTest {
         LoginService loginService = new LoginService(LocalDriverPool.getPage());
         EditorPage editorPage = loginService.login(new UserData(MANAGER_LOGIN, MANAGER_PASSWORD));
 
+        // React nav: open the project from the /projects list, then open the Sync dialog from the editor
+        // toolbar (the Sync dialog + bypass confirm are already React components).
         RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.refresh();
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_NAME);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().openProjectAndWait();
+        repositoryPage.openProject(PROJECT_NAME);
+        EditorPage editor = repositoryPage.getTabSwitcherComponent()
+                .selectTab(TabSwitcherComponent.TabName.EDITOR);
+        editor.getEditorLeftProjectModuleSelectorComponent().selectProject(PROJECT_NAME);
 
         SyncChangesDialogComponent syncDialog = repositoryPage.getSyncChangesDialogComponent();
         WaitUtil.waitForCondition(() -> {
-            repositoryPage.getRepositoryContentButtonsPanelComponent().clickSync();
+            editor.getEditorToolbarPanelComponent().clickSync();
             return syncDialog.isVisible();
         }, 15_000, 1_000, "Click Sync until the merge dialog appears");
         syncDialog.selectBranch(PROTECTED_TARGET);

--- a/src/test/java/tests/ui/webstudio/git/TestProtectedBranchBypassCancelMergeUi.java
+++ b/src/test/java/tests/ui/webstudio/git/TestProtectedBranchBypassCancelMergeUi.java
@@ -54,17 +54,18 @@ public class TestProtectedBranchBypassCancelMergeUi extends BaseTest {
         LoginService loginService = new LoginService(LocalDriverPool.getPage());
         EditorPage editorPage = loginService.login(new UserData(MANAGER_LOGIN, MANAGER_PASSWORD));
 
+        // React nav: open the project from the /projects list, then open the Sync dialog from the editor
+        // toolbar (the Sync dialog + bypass confirm are already React components).
         RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.refresh();
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_NAME);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().openProjectAndWait();
+        repositoryPage.openProject(PROJECT_NAME);
+        EditorPage editor = repositoryPage.getTabSwitcherComponent()
+                .selectTab(TabSwitcherComponent.TabName.EDITOR);
+        editor.getEditorLeftProjectModuleSelectorComponent().selectProject(PROJECT_NAME);
 
         SyncChangesDialogComponent syncDialog = repositoryPage.getSyncChangesDialogComponent();
         WaitUtil.waitForCondition(() -> {
-            repositoryPage.getRepositoryContentButtonsPanelComponent().clickSync();
+            editor.getEditorToolbarPanelComponent().clickSync();
             return syncDialog.isVisible();
         }, 15_000, 1_000, "Click Sync until the merge dialog appears");
         syncDialog.selectBranch(PROTECTED_TARGET);

--- a/src/test/java/tests/ui/webstudio/git/TestProtectedBranchBypassContributorBlockedUi.java
+++ b/src/test/java/tests/ui/webstudio/git/TestProtectedBranchBypassContributorBlockedUi.java
@@ -54,17 +54,18 @@ public class TestProtectedBranchBypassContributorBlockedUi extends BaseTest {
         EditorPage editorPage = loginService.login(
                 new UserData(CONTRIBUTOR_LOGIN, CONTRIBUTOR_PASSWORD));
 
+        // React nav: open the project from the /projects list, then open the Sync dialog from the editor
+        // toolbar (the Sync dialog + bypass confirm are already React components).
         RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.refresh();
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_NAME);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().openProjectAndWait();
+        repositoryPage.openProject(PROJECT_NAME);
+        EditorPage editor = repositoryPage.getTabSwitcherComponent()
+                .selectTab(TabSwitcherComponent.TabName.EDITOR);
+        editor.getEditorLeftProjectModuleSelectorComponent().selectProject(PROJECT_NAME);
 
         SyncChangesDialogComponent syncDialog = repositoryPage.getSyncChangesDialogComponent();
         WaitUtil.waitForCondition(() -> {
-            repositoryPage.getRepositoryContentButtonsPanelComponent().clickSync();
+            editor.getEditorToolbarPanelComponent().clickSync();
             return syncDialog.isVisible();
         }, 15_000, 1_000, "Click Sync until the merge dialog appears");
         syncDialog.selectBranch(PROTECTED_TARGET);

--- a/src/test/java/tests/ui/webstudio/git/TestProtectedBranchBypassIdempotentRetryUi.java
+++ b/src/test/java/tests/ui/webstudio/git/TestProtectedBranchBypassIdempotentRetryUi.java
@@ -55,17 +55,18 @@ public class TestProtectedBranchBypassIdempotentRetryUi extends BaseTest {
         LoginService loginService = new LoginService(LocalDriverPool.getPage());
         EditorPage editorPage = loginService.login(new UserData(MANAGER_LOGIN, MANAGER_PASSWORD));
 
+        // React nav: open the project from the /projects list, then open the Sync dialog from the editor
+        // toolbar (the Sync dialog + bypass confirm are already React components).
         RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.refresh();
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_NAME);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().openProjectAndWait();
+        repositoryPage.openProject(PROJECT_NAME);
+        EditorPage editor = repositoryPage.getTabSwitcherComponent()
+                .selectTab(TabSwitcherComponent.TabName.EDITOR);
+        editor.getEditorLeftProjectModuleSelectorComponent().selectProject(PROJECT_NAME);
 
         SyncChangesDialogComponent syncDialog = repositoryPage.getSyncChangesDialogComponent();
         WaitUtil.waitForCondition(() -> {
-            repositoryPage.getRepositoryContentButtonsPanelComponent().clickSync();
+            editor.getEditorToolbarPanelComponent().clickSync();
             return syncDialog.isVisible();
         }, 15_000, 1_000, "Click Sync until the merge dialog appears");
         syncDialog.selectBranch(PROTECTED_TARGET);
@@ -78,13 +79,16 @@ public class TestProtectedBranchBypassIdempotentRetryUi extends BaseTest {
                 .as("first bypass merge succeeds with a '%s' toast", MERGE_SUCCESS_TOAST)
                 .isTrue();
 
-        // After the merge the Repository view drops back to the project list — re-select the
-        // project before re-opening Sync for the same direction.
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_NAME);
+        // After the merge the project may drop from the editor workspace — re-open it if needed, then
+        // re-open the Sync dialog from the editor toolbar for the same direction.
+        repositoryPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.REPOSITORY);
+        if (repositoryPage.isProjectActionAvailable(PROJECT_NAME, "Open")) {
+            repositoryPage.openProject(PROJECT_NAME);
+        }
+        editor.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
+        editor.getEditorLeftProjectModuleSelectorComponent().selectProject(PROJECT_NAME);
         WaitUtil.waitForCondition(() -> {
-            repositoryPage.getRepositoryContentButtonsPanelComponent().clickSync();
+            editor.getEditorToolbarPanelComponent().clickSync();
             return syncDialog.isVisible();
         }, 15_000, 1_000, "Re-open the Sync dialog after the merge");
         syncDialog.selectBranch(PROTECTED_TARGET);

--- a/src/test/java/tests/ui/webstudio/git/TestProtectedBranchBypassManagerMergeUi.java
+++ b/src/test/java/tests/ui/webstudio/git/TestProtectedBranchBypassManagerMergeUi.java
@@ -52,18 +52,18 @@ public class TestProtectedBranchBypassManagerMergeUi extends BaseTest {
         LoginService loginService = new LoginService(LocalDriverPool.getPage());
         EditorPage editorPage = loginService.login(new UserData(MANAGER_LOGIN, MANAGER_PASSWORD));
 
+        // React nav: open the project from the /projects list, then open the Sync dialog from the editor
+        // toolbar (the Sync dialog + bypass confirm are already React components).
         RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.refresh();
+        repositoryPage.openProject(PROJECT_NAME);
+        EditorPage editor = repositoryPage.getTabSwitcherComponent()
+                .selectTab(TabSwitcherComponent.TabName.EDITOR);
+        editor.getEditorLeftProjectModuleSelectorComponent().selectProject(PROJECT_NAME);
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_NAME);
-
-        repositoryPage.getRepositoryContentButtonsPanelComponent().openProjectAndWait();
         SyncChangesDialogComponent syncDialog = repositoryPage.getSyncChangesDialogComponent();
         helpers.utils.WaitUtil.waitForCondition(() -> {
-            repositoryPage.getRepositoryContentButtonsPanelComponent().clickSync();
+            editor.getEditorToolbarPanelComponent().clickSync();
             return syncDialog.isVisible();
         }, 15_000, 1_000, "Click Sync until the merge dialog appears");
         syncDialog.selectBranch(PROTECTED_TARGET);

--- a/src/test/java/tests/ui/webstudio/git/TestProtectedBranchBypassSettingOffUi.java
+++ b/src/test/java/tests/ui/webstudio/git/TestProtectedBranchBypassSettingOffUi.java
@@ -52,17 +52,18 @@ public class TestProtectedBranchBypassSettingOffUi extends BaseTest {
         LoginService loginService = new LoginService(LocalDriverPool.getPage());
         EditorPage editorPage = loginService.login(new UserData(MANAGER_LOGIN, MANAGER_PASSWORD));
 
+        // React nav: open the project from the /projects list, then open the Sync dialog from the editor
+        // toolbar (the Sync dialog + bypass confirm are already React components).
         RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.refresh();
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_NAME);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().openProjectAndWait();
+        repositoryPage.openProject(PROJECT_NAME);
+        EditorPage editor = repositoryPage.getTabSwitcherComponent()
+                .selectTab(TabSwitcherComponent.TabName.EDITOR);
+        editor.getEditorLeftProjectModuleSelectorComponent().selectProject(PROJECT_NAME);
 
         SyncChangesDialogComponent syncDialog = repositoryPage.getSyncChangesDialogComponent();
         WaitUtil.waitForCondition(() -> {
-            repositoryPage.getRepositoryContentButtonsPanelComponent().clickSync();
+            editor.getEditorToolbarPanelComponent().clickSync();
             return syncDialog.isVisible();
         }, 15_000, 1_000, "Click Sync until the merge dialog appears");
         syncDialog.selectBranch(PROTECTED_TARGET);

--- a/src/test/java/tests/ui/webstudio/git/TestProtectedBranchMergeProtection.java
+++ b/src/test/java/tests/ui/webstudio/git/TestProtectedBranchMergeProtection.java
@@ -11,7 +11,6 @@ import domain.ui.webstudio.components.admincomponents.RepositoriesPageComponent;
 import domain.ui.webstudio.components.common.CreateNewProjectComponent;
 import domain.ui.webstudio.components.common.SyncChangesDialogComponent;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
-import domain.ui.webstudio.components.repositorytabcomponents.CopyProjectDialogComponent;
 import domain.ui.webstudio.pages.mainpages.AdminPage;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
@@ -46,18 +45,10 @@ public class TestProtectedBranchMergeProtection extends BaseTest {
 
         RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.REPOSITORY);
         repositoryPage.createProject(CreateNewProjectComponent.TabName.ZIP_ARCHIVE, PROJECT_NAME, "TestMergeBranchesNoConflicts_NoConflicts.zip");
-        repositoryPage.refresh();
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_NAME);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickCopyBtn();
-
-        CopyProjectDialogComponent copyDialog = repositoryPage.getCopyProjectDialogComponent();
-        copyDialog.waitForDialogToAppear()
-                .setNewBranchName(BRANCH_NAME)
-                .clickCopyButton();
-        repositoryPage.refresh();
+        // React: "copy the project into a new branch" is the project-detail Branches tab "New branch" action;
+        // switch onto the new branch so the later Sync merges from it into the protected master.
+        repositoryPage.openProjectDetail(PROJECT_NAME).createBranch(BRANCH_NAME, true);
 
         AdminPage adminPage = editorPage.openUserMenu().navigateToAdministration();
         RepositoriesPageComponent repositories = adminPage.navigateToRepositoriesPage();
@@ -66,14 +57,14 @@ public class TestProtectedBranchMergeProtection extends BaseTest {
                 .applyChangesAndRelogin(User.ADMIN);
 
         repositoryPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_NAME);
-        assertThat(repositoryPage.getRepositoryContentButtonsPanelComponent().isSyncButtonVisible())
+        // The project is already open on the new branch (createBranch switched onto it), so go straight to the editor.
+        EditorPage editor = repositoryPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
+        editor.getEditorLeftProjectModuleSelectorComponent().selectProject(PROJECT_NAME);
+        assertThat(editor.getEditorToolbarPanelComponent().isSyncButtonVisible())
                 .as("Sync button should be visible after branching")
                 .isTrue();
 
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickSync();
+        editor.getEditorToolbarPanelComponent().clickSync();
         SyncChangesDialogComponent syncDialog = repositoryPage.getSyncChangesDialogComponent();
         syncDialog.waitForDialogToAppear();
         syncDialog.selectBranch(MASTER_BRANCH);

--- a/src/test/java/tests/ui/webstudio/repository/TestDeploymentConfigurationRepositoryConnectionMsSql.java
+++ b/src/test/java/tests/ui/webstudio/repository/TestDeploymentConfigurationRepositoryConnectionMsSql.java
@@ -16,6 +16,7 @@ import helpers.service.DeployInfrastructureService;
 import helpers.service.LoginService;
 import helpers.service.UserService;
 import helpers.utils.DbVerificationUtil;
+import helpers.utils.WaitUtil;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -75,12 +76,7 @@ public class TestDeploymentConfigurationRepositoryConnectionMsSql extends BaseTe
         RepositoryPage repositoryPage = new RepositoryPage();
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, projectName, "Example 1 - Bank Rating");
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeploy();
-
-        DeployModalComponent deployModal = repositoryPage.getDeployModalComponent();
+        DeployModalComponent deployModal = repositoryPage.clickDeploy(projectName);
         deployModal.deployWithAllFields(null, deploymentName, "MS SQL JDBC deploy test");
 
         assertThat(deployModal.isSuccessNotificationVisible())
@@ -91,13 +87,23 @@ public class TestDeploymentConfigurationRepositoryConnectionMsSql extends BaseTe
     }
 
     private void verifyMsSqlContainsDeployedData() {
-        List<Map<String, String>> rows = DbVerificationUtil.queryRows(
-                deployInfra.getMsSqlHostJdbcUrl(),
-                deployInfra.getMsSqlContainer().getUsername(),
-                deployInfra.getMsSqlContainer().getPassword(),
-                "SELECT id, file_name, author, file_comment, DATALENGTH(file_data) as file_size FROM openl_repository ORDER BY id");
-        assertThat(rows)
+        String url = deployInfra.getMsSqlHostJdbcUrl();
+        String user = deployInfra.getMsSqlContainer().getUsername();
+        String pass = deployInfra.getMsSqlContainer().getPassword();
+
+        // Deploy to the JDBC production repo propagates asynchronously after the success notification — poll for it.
+        boolean found = WaitUtil.waitForCondition(() -> {
+            try {
+                List<Map<String, String>> rows = DbVerificationUtil.queryRows(url, user, pass,
+                        "SELECT id, file_name, author, file_comment, DATALENGTH(file_data) as file_size FROM openl_repository ORDER BY id");
+                return !rows.isEmpty();
+            } catch (RuntimeException e) {
+                return false;
+            }
+        }, 30000, 2000, "Waiting for MS SQL openl_repository to contain deployed data");
+
+        assertThat(found)
                 .as("MS SQL deployment repository should contain deployed project files")
-                .isNotEmpty();
+                .isTrue();
     }
 }

--- a/src/test/java/tests/ui/webstudio/repository/TestDeploymentConfigurationRepositoryConnectionOracle.java
+++ b/src/test/java/tests/ui/webstudio/repository/TestDeploymentConfigurationRepositoryConnectionOracle.java
@@ -17,6 +17,7 @@ import helpers.service.DeployInfrastructureService;
 import helpers.service.LoginService;
 import helpers.service.UserService;
 import helpers.utils.DbVerificationUtil;
+import helpers.utils.WaitUtil;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -98,13 +99,9 @@ public class TestDeploymentConfigurationRepositoryConnectionOracle extends BaseT
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, projectName, "Example 1 - Bank Rating");
 
         // Step 5: Select the project and deploy it to the Oracle deployment repository
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeploy();
+        DeployModalComponent deployModal = repositoryPage.clickDeploy(projectName);
 
         // Step 6: Fill deploy modal and deploy
-        DeployModalComponent deployModal = repositoryPage.getDeployModalComponent();
         deployModal.deployWithAllFields(null, deploymentName, "Oracle JDBC deploy test");
 
         // Step 7: Wait for deploy to complete (success notification appears)
@@ -117,13 +114,23 @@ public class TestDeploymentConfigurationRepositoryConnectionOracle extends BaseT
     }
 
     private void verifyOracleContainsDeployedData() {
-        List<Map<String, String>> rows = DbVerificationUtil.queryRows(
-                deployInfra.getOracleContainer().getJdbcUrl(),
-                deployInfra.getOracleContainer().getUsername(),
-                deployInfra.getOracleContainer().getPassword(),
-                "SELECT id, file_name, author, file_comment, modified_at, dbms_lob.getlength(file_data) as file_size FROM openl_repository ORDER BY id");
-        assertThat(rows)
+        String url = deployInfra.getOracleContainer().getJdbcUrl();
+        String user = deployInfra.getOracleContainer().getUsername();
+        String pass = deployInfra.getOracleContainer().getPassword();
+
+        // Deploy to the JDBC production repo propagates asynchronously after the success notification — poll for it.
+        boolean found = WaitUtil.waitForCondition(() -> {
+            try {
+                List<Map<String, String>> rows = DbVerificationUtil.queryRows(url, user, pass,
+                        "SELECT id, file_name, author, file_comment, dbms_lob.getlength(file_data) as file_size FROM openl_repository ORDER BY id");
+                return !rows.isEmpty();
+            } catch (RuntimeException e) {
+                return false;
+            }
+        }, 30000, 2000, "Waiting for Oracle openl_repository to contain deployed data");
+
+        assertThat(found)
                 .as("Oracle deployment repository should contain deployed project files")
-                .isNotEmpty();
+                .isTrue();
     }
 }

--- a/src/test/java/tests/ui/webstudio/repository/TestMultipleDesignRepositoriesWithPostgres.java
+++ b/src/test/java/tests/ui/webstudio/repository/TestMultipleDesignRepositoriesWithPostgres.java
@@ -10,9 +10,10 @@ import domain.ui.webstudio.components.admincomponents.RepositoriesPageComponent;
 import domain.ui.webstudio.components.common.CreateNewProjectComponent;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
 import domain.ui.webstudio.components.editortabcomponents.EditProjectDialogComponent;
-import domain.ui.webstudio.components.repositorytabcomponents.RepositoryContentTabPropertiesComponent;
+import domain.ui.webstudio.components.repositorytabcomponents.CopyProjectDialogComponent;
 import domain.ui.webstudio.pages.mainpages.AdminPage;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
+import domain.ui.webstudio.pages.mainpages.ProjectDetailPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
 import helpers.service.DeployInfrastructureService;
 import helpers.service.LoginService;
@@ -33,17 +34,12 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Migrated from: Repository/TestMultipleDesignRepositoriesWithPostgres.java
- * Ticket: IPBQA-30859
+ * Ticket: IPBQA-30859 — Multiple Design Repositories (Git flat + Git non-flat + JDBC security DB).
  *
- * Adaptation: Instead of using a pre-deployed PostgreSQL instance (used in legacy @BeforeMethod
- * clearDB() for test isolation), each test run spins up a PostgreSQL container via Testcontainers.
- * The container is configured as the Studio's users/security database via app container env vars,
- * demonstrating JDBC integration. Since each test gets a fresh container, clearDB() is not needed.
- *
- * All containers share a Docker network (created here and registered in NetworkPool).
- * The app container joins the same network via BaseTest support for pre-registered networks.
- * PostgreSQL is accessible via Docker DNS alias "postgres" — no host.docker.internal dependency.
+ * React repository (build 032c60a664ce+): create/copy target a specific repository via the wizard/copy-dialog
+ * repository selector + path field; status lives in the project detail (Opened/Closed, not "No Changes"/"Closed");
+ * two same-name projects across repos are disambiguated by open/closed state (openProjectDetailByState). The
+ * legacy branch/separate-project copy options were removed.
  */
 public class TestMultipleDesignRepositoriesWithPostgres extends BaseTest {
 
@@ -60,15 +56,10 @@ public class TestMultipleDesignRepositoriesWithPostgres extends BaseTest {
     public void beforeMethod(ITestResult result) {
         additionalContainerConfig.clear();
         additionalContainerFiles.clear();
-
-        deployInfra = DeployInfrastructureService.builder()
-                .withPostgresAsSecurityDb()
-                .build();
+        deployInfra = DeployInfrastructureService.builder().withPostgresAsSecurityDb().build();
         deployInfra.start();
-
         additionalContainerConfig.putAll(deployInfra.getContainerConfig());
         additionalContainerFiles.putAll(deployInfra.getFilesToCopy());
-
         super.beforeMethod(result);
     }
 
@@ -83,278 +74,132 @@ public class TestMultipleDesignRepositoriesWithPostgres extends BaseTest {
 
     @Test
     @TestCaseId("IPBQA-30859")
-    @Description("Multiple Design Repositories: Git flat, Git non-flat, and JDBC security DB — project management across repos")
+    @Description("Multiple Design Repositories: create/copy across Git repos with JDBC security DB")
     @AppContainerConfig(startParams = AppContainerStartParameters.DEFAULT_STUDIO_PARAMS)
     public void testMultipleDesignRepositoriesWithPostgres() {
-        // Step 0: Login and verify PostgreSQL is actually used as security DB
+        // Step 0: Login and verify PostgreSQL is used as the security DB
         EditorPage editorPage = new LoginService(LocalDriverPool.getPage()).login(UserService.getUser(User.ADMIN));
         verifyPostgresContainsOpenLTables();
 
-        // Step 1: Create project in default Design repository
+        // Step 1: Create a project in the default Design repository
         editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.REPOSITORY);
         RepositoryPage repositoryPage = new RepositoryPage();
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, nameProjectDesign, "Example 1 - Bank Rating");
 
-        // Step 2: Add second design repository (Design1 — Git non-flat)
+        // Step 2: Add a second design repository (Design1) and check its defaults
         AdminPage adminPage = editorPage.openUserMenu().navigateToAdministration();
         RepositoriesPageComponent reposPage = adminPage.navigateToRepositoriesPage();
         reposPage.addDesignRepository();
-        // After clicking Add, the form auto-shows the new Design1 repo (active panel)
-        // Form fields are scoped to ant-tabs-tabpane-active, so they correctly read Design1 values
-
-        // Assert default values of newly added Design1 repository
         assertThat(reposPage.getDesignRepositoryNameValue()).isEqualTo("Design1");
         assertThat(reposPage.getDesignRepositoryType()).isEqualTo("Git");
-        // New UI has no remote/local checkbox — local path confirms it's not remote
         assertThat(reposPage.getDesignRepositoryLocalPath()).contains("repositories/design1");
-
-        // New UI: no flat/non-flat checkbox — Design1 is non-flat by default (has path-in-repository support)
-        // Just save Design1 repository to persist it
         reposPage.applyChangesAndRelogin(User.ADMIN);
 
-        // Step 3: Open Repository tab and check create project dialog repository selectors
+        // Step 3: Create-project wizard shows a repository selector + path field once >1 repo exists
         editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.REPOSITORY);
         repositoryPage = new RepositoryPage();
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, nameProjectDesign + "_check", "", false);
-
-        // Template tab: default = "-- Select a repository --"
-        assertThat(repositoryPage.getCreateNewProjectComponent().getTemplateTabComponent().getRepositorySelectValue())
-                .isEqualTo("-- Select a repository --");
-        repositoryPage.getCreateNewProjectComponent().getTemplateTabComponent().selectRepository("Design");
-        // In new WebStudio, path-in-repository field is shown for all repo types (flat/non-flat distinction removed from dialog)
-        assertThat(repositoryPage.getCreateNewProjectComponent().getTemplateTabComponent().isPathInRepositoryVisible())
-                .isTrue();
-
-        // Switch to Design1 (non-flat) — path field should appear
-        repositoryPage.getCreateNewProjectComponent().getTemplateTabComponent().selectRepository("Design1");
-        assertThat(repositoryPage.getCreateNewProjectComponent().getTemplateTabComponent().isPathInRepositoryVisible())
-                .isTrue();
-        assertThat(repositoryPage.getCreateNewProjectComponent().getTemplateTabComponent().getPathInRepositoryValue())
-                .isEqualTo("/");
-
-        // Step 3.1: "Repository" tab (import from repository) — only Design1 available (non-flat only)
-        // NOTE: The exact locators for the "Repository" import tab may need verification
-        // Legacy: fromRepositoryRepository.getAllValues() containsOnly("-- Select a repository --", "Design1")
-        // The path field for "from repository" should be present by default
-
-        // Close Create Project dialog
+        CreateNewProjectComponent wizard = repositoryPage.getCreateNewProjectComponent();
+        wizard.selectRepository("Design");
+        assertThat(wizard.isPathInRepositoryVisible()).as("Path field should be shown for the Design repo").isTrue();
+        wizard.selectRepository("Design1");
+        assertThat(wizard.isPathInRepositoryVisible()).as("Path field should be shown for the Design1 repo").isTrue();
         repositoryPage.getCreateNewProjectComponent().cancelCreation();
 
-        // Step 4: Create ProjectDesign1Repo in Design1 with path /new/
-        repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, nameProjectDesign1,
-                "Example 2 - Corporate Rating", false);
-        repositoryPage.getCreateNewProjectComponent().getTemplateTabComponent()
-                .selectRepository("Design1")
-                .setPathInRepository("/new/");
-        repositoryPage.getCreateNewProjectComponent().getTemplateTabComponent().clickCreate();
+        // Step 4: Create ProjectDesign1Repo in Design1 at path /new/
+        repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, nameProjectDesign1, "Example 2 - Corporate Rating", false);
+        wizard = repositoryPage.getCreateNewProjectComponent();
+        wizard.selectRepository("Design1").setPathInRepository("new").clickCreate();
         repositoryPage.fillCommitInfo();
         repositoryPage.waitUntilSpinnerLoaded();
-        repositoryPage.refresh();
+        // In a non-flat repo, a project created at path "new" renders with a PATH-PREFIXED row name ("new"+name).
+        // Both repos' projects are shown by default (repo filters unchecked = show-all), so no filter toggling.
+        String design1RowName = "new" + nameProjectDesign1;
+        ProjectDetailPage detail = repositoryPage.openProjectsList().openProjectDetail(design1RowName);
+        assertThat(detail.getOverviewPath()).as("ProjectDesign1Repo path").contains("new" + nameProjectDesign1);
+        assertThat(detail.getOverviewRepository()).as("ProjectDesign1Repo repository").isEqualTo("Design1");
+        repositoryPage.openProjectsList();
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", nameProjectDesign1);
-        RepositoryContentTabPropertiesComponent propsTab =
-                repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propsTab.getPath()).isEqualTo("new/" + nameProjectDesign1);
-
-        // Step 5: Copy ProjectDesignRepo to Design1 with path /copied/ as nameCopiedProjectToDesign1
+        // A non-flat-repo project created at path P has a PATH-PREFIXED row name (P + name, no slash), and its
+        // Overview "Path" reads the same (P + name). Flat/Design projects keep their bare name.
+        // Step 5: Copy ProjectDesignRepo (flat) to Design1 at "copied" as nameCopiedProjectToDesign1
+        // COPY into a path yields a BARE row name (just the new name), unlike CREATE (which path-prefixes).
         String nameCopiedProjectToDesign1 = "nameCopiedProjectToDesign1";
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .selectItemInFolder("Projects", nameProjectDesign);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickCopyBtn();
-        repositoryPage.getCopyProjectDialogComponent()
-                .waitForDialogToAppear()
-                .setSeparateProject(true)
-                .setNewProjectName(nameCopiedProjectToDesign1)
-                .selectRepository("Design1")
-                .setProjectFolder("/copied")
-                .clickCopyButton();
+        CopyProjectDialogComponent copyDialog = repositoryPage.clickCopyAction(nameProjectDesign);
+        copyDialog.setNewProjectName(nameCopiedProjectToDesign1).selectRepository("Design1").setProjectFolder("copied").clickCopyButton();
+        repositoryPage.fillCommitInfo();
+        repositoryPage.waitUntilSpinnerLoaded();
+        detail = repositoryPage.openProjectsList().openProjectDetail(nameCopiedProjectToDesign1);
+        assertThat(detail.getOverviewRepository()).isEqualTo("Design1");
+        repositoryPage.openProjectsList();
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .selectItemInFolder("Projects", nameCopiedProjectToDesign1);
-        propsTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propsTab.getPath()).isEqualTo("copied/" + nameCopiedProjectToDesign1);
-        assertThat(propsTab.getRepository()).isEqualTo("Design1");
-
-        // Step 6: Copy ProjectDesign1Repo to Design as nameCopiedProjectFromDesign1
+        // Step 6: Copy ProjectDesign1Repo (row "new"+name) to Design (flat) as nameCopiedProjectFromDesign1
         String nameCopiedProjectFromDesign1 = "nameCopiedProjectFromDesign1";
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .selectItemInFolder("Projects", nameProjectDesign1);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickCopyBtn();
-        repositoryPage.getCopyProjectDialogComponent()
-                .waitForDialogToAppear()
-                .setSeparateProject(true)
-                .setNewProjectName(nameCopiedProjectFromDesign1)
-                .selectRepository("Design")
-                .clickCopyButton();
+        copyDialog = repositoryPage.clickCopyAction(design1RowName);
+        copyDialog.setNewProjectName(nameCopiedProjectFromDesign1).selectRepository("Design").clickCopyButton();
+        repositoryPage.fillCommitInfo();
+        repositoryPage.waitUntilSpinnerLoaded();
+        detail = repositoryPage.openProjectsList().openProjectDetail(nameCopiedProjectFromDesign1);
+        assertThat(detail.getOverviewRepository()).isEqualTo("Design");
+        repositoryPage.openProjectsList();
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .selectItemInFolder("Projects", nameCopiedProjectFromDesign1);
-        propsTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propsTab.getRepository()).isEqualTo("Design");
+        // Step 7: Copy ProjectDesignRepo to Design1 at "step7" with the SAME name. COPY yields a BARE row name,
+        // so there are now TWO rows named "ProjectDesignRepo" (Design original = Opened, Design1 copy = Closed) —
+        // disambiguate by state.
+        copyDialog = repositoryPage.clickCopyAction(nameProjectDesign);
+        copyDialog.setNewProjectName(nameProjectDesign).selectRepository("Design1").setProjectFolder("step7").clickCopyButton();
+        repositoryPage.fillCommitInfo();
+        repositoryPage.waitUntilSpinnerLoaded();
 
-        // Step 7: Copy ProjectDesignRepo to Design1 (same name) — conflict/closed scenario
-        // New UI requires explicit path for non-flat repos (legacy didn't set path)
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .selectItemInFolder("Projects", nameProjectDesign);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickCopyBtn();
-        repositoryPage.getCopyProjectDialogComponent()
-                .waitForDialogToAppear()
-                .setSeparateProject(true)
-                .setNewProjectName(nameProjectDesign)
-                .selectRepository("Design1")
-                .setProjectFolder("/step7")
-                .clickCopyButton();
+        // The opened original (Design) still shows Opened
+        detail = repositoryPage.openProjectsList().openProjectDetailByState(nameProjectDesign, true);
+        assertThat(detail.getStatus()).as("Opened original status").isEqualTo("Opened");
+        // The closed copy (Design1)
+        detail = repositoryPage.openProjectsList().openProjectDetailByState(nameProjectDesign, false);
+        assertThat(detail.getOverviewRepository()).isEqualTo("Design1");
+        assertThat(detail.getStatus()).isEqualTo("Closed");
 
-        // After copy, the opened project (Design) should still show No Changes
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .selectOpenedItemInFolder("Projects", nameProjectDesign);
-        propsTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propsTab.getStatus()).isEqualTo("No Changes");
-
-        // The copy creates a closed version visible in the tree (closed.gif icon)
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .selectClosedItemInFolder("Projects", nameProjectDesign);
-        propsTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propsTab.getName()).isEqualTo(nameProjectDesign);
-        assertThat(propsTab.getPath()).isEqualTo("step7/" + nameProjectDesign);
-        assertThat(propsTab.getRepository()).isEqualTo("Design1");
-        assertThat(propsTab.getStatus()).isEqualTo("Closed");
-
-        // Step 7.1: Try to open the closed project — the duplicate-name error now surfaces as a
-        // React toast notification (ant-notification); its text lives in the notice description,
-        // so match the whole notice rather than the legacy top-of-page closable message.
-        repositoryPage.getRepositoryContentButtonsPanelComponent().openProject();
-        assertThat(WaitUtil.waitForCondition(
-                () -> LocalDriverPool.getPage().locator("xpath=//div[contains(@class,'ant-notification-notice')]"
-                        + "[contains(normalize-space(.),'Cannot open two projects with the same name')]").count() > 0,
-                10000, 500, "Waiting for the duplicate-name error notification"))
-                .as("Opening a second project with the same name must be blocked with an error notification")
-                .isTrue();
+        // Step 7.1: Opening the closed same-name copy is blocked with a duplicate-name error notification
+        repositoryPage.openProjectsList().openProjectByState(nameProjectDesign, false);
+        assertThat(waitForDuplicateNameError())
+                .as("Opening a second project with the same name must be blocked").isTrue();
         repositoryPage.closeAllMessages();
 
-        // Step 8: Try to copy again to Design1 with /copied/ path — should show duplicate error
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickCopyBtn();
-        repositoryPage.getCopyProjectDialogComponent()
-                .waitForDialogToAppear()
-                .setSeparateProject(true)
-                .setNewProjectName(nameProjectDesign)
-                .selectRepository("Design1")
-                .setProjectFolder("/copied")
-                .clickCopyButton(false);
-        List<String> copyErrors = repositoryPage.getCopyProjectDialogComponent().getErrors();
-        assertThat(copyErrors).anyMatch(e -> e.contains("Project with this name already exists"));
-        repositoryPage.getCopyProjectDialogComponent().clickCancelButton();
+        // Step 8: Copy the opened original again to Design1 at "copied" with the same name → duplicate error
+        copyDialog = repositoryPage.clickCopyActionByState(nameProjectDesign, true);
+        copyDialog.setNewProjectName(nameProjectDesign).selectRepository("Design1").setProjectFolder("copied").clickCopyButton(false);
+        assertThat(copyDialog.waitForErrors(5000)).anyMatch(e -> e.contains("already exists"));
+        copyDialog.clickCancelButton();
 
-        // Step 9: Copy ProjectDesign1Repo to Design (another copy)
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .selectItemInFolder("Projects", nameProjectDesign1);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickCopyBtn();
-        repositoryPage.getCopyProjectDialogComponent()
-                .waitForDialogToAppear()
-                .setSeparateProject(true)
-                .setNewProjectName(nameProjectDesign1)
-                .selectRepository("Design")
-                .clickCopyButton();
-
-        // After copy, the opened project (Design1) should still show No Changes
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .selectOpenedItemInFolder("Projects", nameProjectDesign1);
-        propsTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propsTab.getRepository()).isEqualTo("Design1");
-        assertThat(propsTab.getStatus()).isEqualTo("No Changes");
-
-        // The closed copy in Design repo (closed.gif icon)
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .selectClosedItemInFolder("Projects", nameProjectDesign1);
-        propsTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propsTab.getName()).isEqualTo(nameProjectDesign1);
-        assertThat(propsTab.getRepository()).isEqualTo("Design");
-        assertThat(propsTab.getStatus()).isEqualTo("Closed");
-
-        // Step 9.1: Open closed copy — the duplicate-name error surfaces as a React toast notification
-        // whose text lives in the notice description; match the whole notice.
-        repositoryPage.getRepositoryContentButtonsPanelComponent().openProject();
-        assertThat(WaitUtil.waitForCondition(
-                () -> LocalDriverPool.getPage().locator("xpath=//div[contains(@class,'ant-notification-notice')]"
-                        + "[contains(normalize-space(.),'Cannot open two projects with the same name')]").count() > 0,
-                10000, 500, "Waiting for the duplicate-name error notification"))
-                .as("Opening a second project with the same name must be blocked with an error notification")
-                .isTrue();
-        repositoryPage.closeAllMessages();
-
-        // Step 9.2: Switch to Editor tab, rename project in non-flat git repo, then rename back
-        editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
-        editorPage.getEditorLeftProjectModuleSelectorComponent().selectProject(nameProjectDesign1);
-        EditProjectDialogComponent editDialog = editorPage.openEditProjectDialog(nameProjectDesign1);
-        String renamedProject = nameProjectDesign1 + "_Renamed";
-        editDialog.setProjectName(renamedProject);
-        assertThat(editDialog.getProjectName()).isEqualTo(renamedProject);
-        assertThat(editDialog.isUpdateButtonEnabled()).isTrue();
-        editDialog.clickUpdateButton();
-        editorPage.waitUntilSpinnerLoaded();
-
-        // Verify renamed project is reflected in editor
-        editDialog = editorPage.openEditProjectDialog(renamedProject);
-        assertThat(editDialog.getProjectName())
-                .as("Project should be renamed to new name in non-flat git repo")
-                .isEqualTo(renamedProject);
-
-        // Rename back to original so subsequent steps are not affected
-        editDialog.setProjectName(nameProjectDesign1);
-        editDialog.clickUpdateButton();
-        editorPage.waitUntilSpinnerLoaded();
-
-        // Save to return project to "No Changes" state after rename
-        editorPage.getEditorToolbarPanelComponent().clickSave();
-        editorPage.getSaveChangesComponent().getSaveBtn().click();
-        editorPage.waitUntilSpinnerLoaded();
-
-        // Step 10: Switch to ProjectDesignRepo via breadcrumbs — verify Edit Project dialog opens
-        // Legacy asserted project name field was absent for flat repos; new UI always shows it
-        editorPage.getEditorToolbarPanelComponent().selectProjectBreadcrumbs(nameProjectDesign);
-        editDialog = editorPage.openEditProjectDialog(nameProjectDesign);
-        assertThat(editDialog.getProjectName()).isEqualTo(nameProjectDesign);
-        editDialog.clickCancelButton();
-
-        // Switch back to Repository tab for remaining steps
-        editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage = new RepositoryPage();
-
-        // Step 11: Permanently delete ProjectDesignRepo (single-step React modal, no archive/erase)
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .selectOpenedItemInFolder("Projects", nameProjectDesign);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeleteBtn();
-        repositoryPage.getProjectDeleteConfirmModalComponent()
-                .waitForVisible()
+        // Step 11: Permanently delete the opened ProjectDesignRepo original (a same-name closed copy also exists)
+        repositoryPage.openProjectsList();
+        repositoryPage.deleteProjectByState(nameProjectDesign, true)
                 .enterDeletionComment("Removed by automated regression test")
                 .acknowledgePermanentDeletion()
                 .clickDelete();
-        repositoryPage.waitUntilSpinnerLoaded();
-        repositoryPage.refresh();
+        repositoryPage.openProjectsList();
 
-        // Step 12: Permanently delete ProjectDesign1Repo
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .selectOpenedItemInFolder("Projects", nameProjectDesign1);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeleteBtn();
-        repositoryPage.getProjectDeleteConfirmModalComponent()
-                .waitForVisible()
+        // Step 12: Permanently delete ProjectDesign1Repo (Design1 at path → row name is path-prefixed)
+        repositoryPage.deleteProject(design1RowName)
                 .enterDeletionComment("Removed by automated regression test")
                 .acknowledgePermanentDeletion()
                 .clickDelete();
-        repositoryPage.waitUntilSpinnerLoaded();
+    }
+
+    private boolean waitForDuplicateNameError() {
+        return WaitUtil.waitForCondition(
+                () -> LocalDriverPool.getPage().locator("xpath=//div[contains(@class,'ant-notification-notice')]"
+                        + "[contains(normalize-space(.),'Cannot open two projects with the same name')]").count() > 0,
+                10000, 500, "Waiting for the duplicate-name error notification");
     }
 
     private void verifyPostgresContainsOpenLTables() {
         PostgreSQLContainer<?> pg = deployInfra.getPostgresContainer();
         List<String> tables = DbVerificationUtil.queryTableNames(
-                pg.getJdbcUrl(),
-                pg.getUsername(),
-                pg.getPassword(),
+                pg.getJdbcUrl(), pg.getUsername(), pg.getPassword(),
                 "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name LIKE 'openl_%' ORDER BY table_name");
         assertThat(tables)
-                .as("PostgreSQL should contain OpenL security tables — proves it's used instead of embedded H2")
+                .as("PostgreSQL should contain OpenL security tables")
                 .isNotEmpty()
                 .anyMatch(t -> t.contains("openl_users"))
                 .anyMatch(t -> t.contains("openl_groups"));

--- a/src/test/java/tests/ui/webstudio/repository/TestNewDeployPopup.java
+++ b/src/test/java/tests/ui/webstudio/repository/TestNewDeployPopup.java
@@ -10,7 +10,6 @@ import domain.ui.webstudio.components.common.CreateNewProjectComponent;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
 import domain.ui.webstudio.components.editortabcomponents.leftmenu.EditorLeftRulesTreeComponent;
 import domain.ui.webstudio.components.repositorytabcomponents.DeployModalComponent;
-import domain.ui.webstudio.components.repositorytabcomponents.RepositoryContentTabPropertiesComponent;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
 import helpers.service.DeployInfrastructureService;
@@ -97,21 +96,12 @@ public class TestNewDeployPopup extends BaseTest {
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE,
                 nameProject, "Example 1 - Bank Rating");
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", nameProject);
-
-        RepositoryContentTabPropertiesComponent propsTab =
-                repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        String projectInitialRevision = propsTab.getRevision();
+        String projectInitialRevision = repositoryPage.openProjectDetail(nameProject).getLatestRevisionId();
+        repositoryPage.openProjectsList();
         LOGGER.info("Step 1: Project '{}' created, initial revision: {}", nameProject, projectInitialRevision);
 
-        // =========================================================================
-        // STEP 2: Deploy project to production via DeployModal
-        // Legacy steps: 11 (adapted — no Deploy Configuration, direct deploy)
-        // =========================================================================
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeploy();
-        DeployModalComponent deployModal = repositoryPage.getDeployModalComponent();
+        // STEP 2: Deploy project to production via the React DeployModal (project-row Deploy action)
+        DeployModalComponent deployModal = repositoryPage.clickDeploy(nameProject);
         deployModal.deployWithAllFields(null, deploymentName, "First deploy to production");
         assertThat(deployModal.isSuccessNotificationVisible())
                 .as("Deploy should succeed with success notification")
@@ -130,24 +120,13 @@ public class TestNewDeployPopup extends BaseTest {
         String zipFile2 = "Tutorial 6 - Introduction to Spreadsheet Tables.zip";
         String deploymentNameComplex = StringUtil.generateUniqueName("ComplexDeploy");
 
-        // Create Tutorial 3
         repositoryPage.createProject(CreateNewProjectComponent.TabName.ZIP_ARCHIVE,
                 nameDependentProject1, zipFile1);
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", nameDependentProject1);
-
-        // Deploy Tutorial 3 — backend auto-resolves dependency on Tutorial 6
-        // (Tutorial 6 doesn't exist yet, so we create Tutorial 6 first)
-        // Actually, create both projects first, then deploy
         repositoryPage.createProject(CreateNewProjectComponent.TabName.ZIP_ARCHIVE,
                 nameDependentProject2, zipFile2);
 
-        // Deploy Tutorial 3 (has dependency on Tutorial 6)
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .selectItemInFolder("Projects", nameDependentProject1);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeploy();
-        deployModal = repositoryPage.getDeployModalComponent();
+        // Deploy Tutorial 3 (backend auto-resolves the dependency on Tutorial 6)
+        deployModal = repositoryPage.clickDeploy(nameDependentProject1);
         deployModal.deployWithAllFields(null, deploymentNameComplex, "Deploy dependent project");
         assertThat(deployModal.isSuccessNotificationVisible())
                 .as("Deploy of dependent project should succeed")
@@ -161,40 +140,21 @@ public class TestNewDeployPopup extends BaseTest {
         // =========================================================================
         editorPage = repositoryPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.EDITOR);
-        editorPage.getEditorLeftProjectModuleSelectorComponent()
-                .selectModule(nameProject, "Bank Rating");
-        editorPage.getEditorLeftRulesTreeComponent()
-                .setViewFilter(EditorLeftRulesTreeComponent.FilterOptions.BY_TYPE)
-                .expandFolderInTree("Decision")
-                .selectItemInFolder("Decision", "CapitalDynamicScore");
-
-        editorPage.getEditorToolbarPanelComponent().getEditTableBtn().click();
-        editorPage.getCenterTable().editCell(6, 2, "1000");
-        editorPage.getEditorTableActionsPanelComponent().clickSaveChanges();
-        WaitUtil.sleep(1000, "Wait for table save");
+        editProjectCell(editorPage, nameProject, "1000");
 
         repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", nameProject);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickSaveBtn();
-        repositoryPage.getSaveChangesComponent().getSaveBtn().click();
-        WaitUtil.sleep(1000, "Wait for project save");
+        repositoryPage.saveProject(nameProject, "Edit CapitalDynamicScore to 1000");
 
-        propsTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        String projectUpdatedRevision = propsTab.getRevision();
+        String projectUpdatedRevision = repositoryPage.openProjectDetail(nameProject).getLatestRevisionId();
+        repositoryPage.openProjectsList();
         assertThat(projectUpdatedRevision)
                 .as("Revision should change after edit")
                 .isNotEqualTo(projectInitialRevision);
         LOGGER.info("Step 4: Project edited, new revision: {}", projectUpdatedRevision);
 
-        // =========================================================================
-        // STEP 5: Redeploy project with updated revision
-        // Legacy steps: 14 (adapted — just deploy again, same deployment name)
-        // =========================================================================
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeploy();
-        deployModal = repositoryPage.getDeployModalComponent();
+        // STEP 5: Redeploy with the updated revision
+        deployModal = repositoryPage.clickDeploy(nameProject);
         deployModal.deployWithAllFields(null, deploymentName, "Redeploy with updated revision");
         assertThat(deployModal.isSuccessNotificationVisible())
                 .as("Redeploy should succeed")
@@ -209,28 +169,13 @@ public class TestNewDeployPopup extends BaseTest {
         // =========================================================================
         editorPage = repositoryPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.EDITOR);
-        editorPage.getEditorLeftProjectModuleSelectorComponent()
-                .selectModule(nameProject, "Bank Rating");
-        editorPage.getEditorLeftRulesTreeComponent()
-                .setViewFilter(EditorLeftRulesTreeComponent.FilterOptions.BY_TYPE)
-                .expandFolderInTree("Decision")
-                .selectItemInFolder("Decision", "CapitalDynamicScore");
-
-        editorPage.getEditorToolbarPanelComponent().getEditTableBtn().click();
-        editorPage.getCenterTable().editCell(6, 2, "2000");
-        editorPage.getEditorTableActionsPanelComponent().clickSaveChanges();
-        WaitUtil.sleep(1000, "Wait for table save");
+        editProjectCell(editorPage, nameProject, "2000");
 
         repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", nameProject);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickSaveBtn();
-        repositoryPage.getSaveChangesComponent().getSaveBtn().click();
-        WaitUtil.sleep(1000, "Wait for save");
+        repositoryPage.saveProject(nameProject, "Second edit to 2000");
 
-        // Resolve conflict if it appears (legacy behavior from DC save)
+        // Resolve conflict if it appears (deploy targets the production repo, so usually none occurs)
         if (repositoryPage.getResolveConflictsDialogComponent().isDialogVisible()) {
             repositoryPage.getResolveConflictsDialogComponent().resolveConflictUseYours();
             LOGGER.info("Step 6: Conflict resolved using 'Use Yours'");
@@ -238,16 +183,15 @@ public class TestNewDeployPopup extends BaseTest {
             LOGGER.info("Step 6: No conflict occurred (expected in new deploy flow)");
         }
 
-        propsTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        String projectSecondUpdatedRevision = propsTab.getRevision();
+        String projectSecondUpdatedRevision = repositoryPage.openProjectDetail(nameProject).getLatestRevisionId();
+        repositoryPage.openProjectsList();
         assertThat(projectSecondUpdatedRevision)
                 .as("Revision should change after second edit")
                 .isNotEqualTo(projectUpdatedRevision);
         LOGGER.info("Step 6: Second edit done, revision: {}", projectSecondUpdatedRevision);
 
         // Deploy after edit
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeploy();
-        deployModal = repositoryPage.getDeployModalComponent();
+        deployModal = repositoryPage.clickDeploy(nameProject);
         deployModal.deployWithAllFields(null, deploymentName, "Deploy after second edit");
         assertThat(deployModal.isSuccessNotificationVisible())
                 .as("Deploy after second edit should succeed")
@@ -262,12 +206,8 @@ public class TestNewDeployPopup extends BaseTest {
         String nameProjectTutorial2 = "Tutorial 2 - Introduction to Data Tables";
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE,
                 nameProjectTutorial2, nameProjectTutorial2);
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", nameProjectTutorial2);
 
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeploy();
-        deployModal = repositoryPage.getDeployModalComponent();
+        deployModal = repositoryPage.clickDeploy(nameProjectTutorial2);
         deployModal.deployWithAllFields(null, nameProjectTutorial2, "Deploy Tutorial 2");
         assertThat(deployModal.isSuccessNotificationVisible())
                 .as("Deploy of Tutorial 2 should succeed")
@@ -322,4 +262,15 @@ public class TestNewDeployPopup extends BaseTest {
         LOGGER.info("Step 8: WebService verification completed — all services found in WS admin UI");
     }
 
+    private void editProjectCell(EditorPage editorPage, String projectName, String value) {
+        editorPage.getEditorLeftProjectModuleSelectorComponent().selectModule(projectName, "Bank Rating");
+        editorPage.getEditorLeftRulesTreeComponent()
+                .setViewFilter(EditorLeftRulesTreeComponent.FilterOptions.BY_TYPE)
+                .expandFolderInTree("Decision")
+                .selectItemInFolder("Decision", "CapitalDynamicScore");
+        editorPage.getEditorToolbarPanelComponent().getEditTableBtn().click();
+        editorPage.getCenterTable().editCell(6, 2, value);
+        editorPage.getEditorTableActionsPanelComponent().clickSaveChanges();
+        WaitUtil.sleep(1000, "Wait for table save");
+    }
 }

--- a/src/test/java/tests/ui/webstudio/repository/TestRepositoryBrowsingFilterStatus.java
+++ b/src/test/java/tests/ui/webstudio/repository/TestRepositoryBrowsingFilterStatus.java
@@ -10,14 +10,14 @@ import domain.serviceclasses.models.UserData;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
 import domain.ui.webstudio.components.common.CreateNewProjectComponent;
 import domain.ui.webstudio.components.repositorytabcomponents.DeployModalComponent;
-import domain.ui.webstudio.components.repositorytabcomponents.RepositoryContentTabPropertiesComponent;
-import domain.ui.webstudio.pages.mainpages.AdminPage;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
+import domain.ui.webstudio.pages.mainpages.ProjectDetailPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
 import helpers.service.DeployInfrastructureService;
 import helpers.service.LoginService;
 import helpers.service.UserService;
 import helpers.utils.StringUtil;
+import helpers.utils.WaitUtil;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -31,19 +31,16 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /*
- * Covered atomic tests (IPBQA-30010):
- *   2.2.1  - Browsing Design repo: project status lifecycle (No Changes → In Editing → No Changes → Closed → Archived → Closed → No Changes)
- *   2.2.2  - Design repo: Filter by name
- *   2.2.3  - Design repo: Advanced filter (show/hide archived/deleted projects)
- *   2.2.12 - Closing a Project
- *   2.2.14 - Saving a Project
- *   Multi-user locking status (Closed + locked by other user)
- *   Deploy both projects via DeployModal (step 3)
+ * Covered atomic tests (IPBQA-30010) — React repository (build 032c60a664ce+):
+ *   Project status lifecycle (Opened -> Editing -> Opened -> Closed -> Opened), filter by name,
+ *   folder creation, permanent delete, multi-user workspace isolation, deploy both projects.
  *
- * NOT covered:
- *   2.2.4  - Browsing Deployment repo: project pictures by status (Production tab UI not yet mapped)
- *   2.2.5  - Deployment repo: Filter by name (Production tab UI not yet mapped)
- *   Deploy Configuration was removed (EPBDS-15093) — legacy steps 8-11 obsolete
+ * React adaptations (removed/changed behaviour — verified live):
+ *   - The projects table has NO Status/Modified By/Modified At columns (status lives in the project detail),
+ *     so the legacy "6 columns" structure check is dropped and status is read via getProjectStatusFromDetail.
+ *   - Status vocabulary changed: "No Changes" -> "Opened", "In Editing" -> "Editing", "Closed" -> "Closed".
+ *   - The per-user "locked" status was removed: a second user viewing a project another user is editing just
+ *     sees it as "Closed" in their own workspace, so the lock check becomes a workspace-isolation check.
  */
 public class TestRepositoryBrowsingFilterStatus extends BaseTest {
 
@@ -74,18 +71,20 @@ public class TestRepositoryBrowsingFilterStatus extends BaseTest {
     private static final String TEMPLATE_NAME = "Sample Project";
     private static final String SECOND_USER = "repo_filter_second_user";
     private static final String SECOND_USER_PASSWORD = "Test123!";
+    private static final String STATUS_OPENED = "Opened";
+    private static final String STATUS_EDITING = "Editing";
+    private static final String STATUS_CLOSED = "Closed";
 
     @Test
     @TestCaseId("IPBQA-30010")
-    @Description("Repository - Browsing, filter by name, advanced filter, project status lifecycle, multi-user locking")
+    @Description("Repository - Browsing, filter by name, status lifecycle, folder creation, multi-user workspace isolation")
     @AppContainerConfig(startParams = AppContainerStartParameters.DEPLOY_STUDIO_PARAMS)
     public void testRepositoryBrowsingFilterStatus() {
         LoginService loginService = new LoginService(LocalDriverPool.getPage());
         EditorPage editorPage = loginService.login(UserService.getUser(User.ADMIN));
 
         // ===== Step 1: Create second user with Contributor access =====
-        AdminPage adminPage = editorPage.openUserMenu().navigateToAdministration();
-        adminPage.navigateToUsersPage()
+        editorPage.openUserMenu().navigateToAdministration().navigateToUsersPage()
                 .clickAddUser()
                 .setUsername(SECOND_USER)
                 .setEmail(SECOND_USER + "@test.com")
@@ -102,234 +101,105 @@ public class TestRepositoryBrowsingFilterStatus extends BaseTest {
         editorPage = new EditorPage();
         RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, PROJECT_1, TEMPLATE_NAME);
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, PROJECT_2, TEMPLATE_NAME);
 
-        // ===== Step 3: Deploy both projects via DeployModal =====
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_1);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeploy();
-        DeployModalComponent deployModal = repositoryPage.getDeployModalComponent();
-        String deploymentName1 = StringUtil.generateUniqueName("Dep1");
-        deployModal.deployWithAllFields(null, deploymentName1, "Deploy project 1");
-        assertThat(deployModal.isSuccessNotificationVisible())
-                .as("Deploy of PROJECT_1 should succeed")
-                .isTrue();
+        // ===== Step 3: Deploy both projects via the React row Deploy action =====
+        DeployModalComponent deployModal = repositoryPage.clickDeploy(PROJECT_1);
+        deployModal.deployWithAllFields(null, StringUtil.generateUniqueName("Dep1"), "Deploy project 1");
+        assertThat(deployModal.isSuccessNotificationVisible()).as("Deploy of PROJECT_1 should succeed").isTrue();
         repositoryPage.closeAllMessages();
 
-        repositoryPage.refresh();
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_2);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeploy();
-        deployModal = repositoryPage.getDeployModalComponent();
-        String deploymentName2 = StringUtil.generateUniqueName("Dep2");
-        deployModal.deployWithAllFields(null, deploymentName2, "Deploy project 2");
-        assertThat(deployModal.isSuccessNotificationVisible())
-                .as("Deploy of PROJECT_2 should succeed")
-                .isTrue();
+        deployModal = repositoryPage.clickDeploy(PROJECT_2);
+        deployModal.deployWithAllFields(null, StringUtil.generateUniqueName("Dep2"), "Deploy project 2");
+        assertThat(deployModal.isSuccessNotificationVisible()).as("Deploy of PROJECT_2 should succeed").isTrue();
         repositoryPage.closeAllMessages();
 
-        // ===== Step 4: Verify table structure (6 columns) =====
-        // After deploy, the server session remembers the selected project (detail view).
-        // Click the "Projects" folder label in the tree to switch to projects table view.
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectFolderInTree("Projects");
-        List<String> headers = repositoryPage.getProjectsTable().getHeaders();
-        assertThat(headers)
-                .as("Projects table should have 6 columns: Name, Branch, Status, Modified By, Modified At, Actions")
-                .containsExactly("Name", "Branch", "Status", "Modified By", "Modified At", "Actions");
+        // ===== Step 5: Row actions for an open project (repo-level admin: Copy/Export/Delete) =====
+        List<String> p1Actions = repositoryPage.getProjectActionLabels(PROJECT_1);
+        assertThat(p1Actions)
+                .as("Open project should expose Copy/Export/Delete row actions. Actual: %s", p1Actions)
+                .contains("Copy", "Export", "Delete");
 
-        // ===== Step 5: Verify action buttons present for open project =====
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_1);
+        // ===== Step 7: Freshly created project status is "Opened" =====
+        assertThat(repositoryPage.getProjectStatusFromDetail(PROJECT_1))
+                .as("Newly created project status should be 'Opened'").isEqualTo(STATUS_OPENED);
 
-        assertThat(repositoryPage.getRepositoryContentButtonsPanelComponent().isCloseBtnVisible())
-                .as("Close button should be present for opened project")
-                .isTrue();
-        assertThat(repositoryPage.getRepositoryContentButtonsPanelComponent().isCopyBtnVisible())
-                .as("Copy button should be present for opened project")
-                .isTrue();
-        assertThat(repositoryPage.getRepositoryContentButtonsPanelComponent().isExportBtnVisible())
-                .as("Export button should be present for opened project")
-                .isTrue();
-
-        // ===== Step 6: Verify Properties tab available and tabs list =====
-        List<String> availableTabs = repositoryPage.getRepositoryContentTabSwitcherComponent()
-                .getAvailableTabNames();
-        assertThat(availableTabs)
-                .as("Properties tab should be available")
-                .contains("Properties", "Revisions");
-
-        // ===== Step 7: Status "No Changes" for freshly created project =====
-        RepositoryContentTabPropertiesComponent propertiesTab = repositoryPage
-                .getRepositoryContentTabSwitcherComponent()
-                .selectPropertiesTab();
-        assertThat(propertiesTab.getStatus())
-                .as("Newly created project status should be 'No Changes'")
-                .isEqualTo("No Changes");
-
-        // [SKIPPED] Step 8: Deploy Configuration was removed from WebStudio (EPBDS-15093).
-        // Deploy now works directly from project via DeployModal.
-
-        // ===== Step 9: Put project into "In Editing" state via Editor =====
-        editorPage = repositoryPage.getTabSwitcherComponent()
-                .selectTab(TabSwitcherComponent.TabName.EDITOR);
+        // ===== Step 9-10: Put project into "Editing" via the editor edit-project dialog =====
+        editorPage = repositoryPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
         editorPage.getEditorLeftProjectModuleSelectorComponent().selectProject(PROJECT_1);
         editorPage.openEditProjectDialog(PROJECT_1).setDescription("test edit").clickUpdateButton();
+        editorPage.waitUntilSpinnerLoaded();
+        repositoryPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.REPOSITORY);
+        assertThat(repositoryPage.getProjectStatusFromDetail(PROJECT_1))
+                .as("Project status should be 'Editing' after an edit").isEqualTo(STATUS_EDITING);
 
-        // ===== Step 10: Verify "In Editing" status in Repository =====
-        repositoryPage = editorPage.getTabSwitcherComponent()
-                .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_1);
+        // ===== Step 11: Save project → back to "Opened" =====
+        repositoryPage.saveProject(PROJECT_1, "Save after edit");
+        assertThat(repositoryPage.getProjectStatusFromDetail(PROJECT_1))
+                .as("Project status should be 'Opened' after save").isEqualTo(STATUS_OPENED);
 
-        propertiesTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propertiesTab.getStatus())
-                .as("Project status should be 'In Editing' after edit")
-                .isEqualTo("In Editing");
+        // ===== Step 12: Close project → "Closed" =====
+        repositoryPage.closeProject(PROJECT_1);
+        assertThat(repositoryPage.getProjectStatusFromDetail(PROJECT_1))
+                .as("Project status should be 'Closed' after closing").isEqualTo(STATUS_CLOSED);
+        assertThat(repositoryPage.isProjectActionAvailable(PROJECT_1, "Open"))
+                .as("Open row action should appear for a closed project").isTrue();
 
-        // ===== Step 11: Save project → back to "No Changes" =====
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickSaveBtn();
-        repositoryPage.getSaveChangesComponent().getSaveBtn().click();
-        repositoryPage.waitUntilSpinnerLoaded();
-        repositoryPage.refresh();
+        // ===== Step 13: Open the closed project → "Opened" =====
+        repositoryPage.openProject(PROJECT_1);
+        assertThat(repositoryPage.getProjectStatusFromDetail(PROJECT_1))
+                .as("Project status should be 'Opened' after opening").isEqualTo(STATUS_OPENED);
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_1);
-
-        propertiesTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propertiesTab.getStatus())
-                .as("Project status should be 'No Changes' after save")
-                .isEqualTo("No Changes");
-
-        // ===== Step 12: Close project → status "Closed" =====
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickCloseBtn();
-        repositoryPage.refresh();
-
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_1);
-
-        propertiesTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propertiesTab.getStatus())
-                .as("Project status should be 'Closed' after closing")
-                .isEqualTo("Closed");
-        assertThat(repositoryPage.getRepositoryContentButtonsPanelComponent().isOpenBtnVisible())
-                .as("Open button should appear for closed project")
-                .isTrue();
-
-        // ===== Step 13: Open the closed project → status "No Changes" =====
-        repositoryPage.getRepositoryContentButtonsPanelComponent().openProject();
-        repositoryPage.waitUntilSpinnerLoaded();
-        repositoryPage.refresh();
-
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_1);
-
-        propertiesTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propertiesTab.getStatus())
-                .as("Project status should be 'No Changes' after opening")
-                .isEqualTo("No Changes");
-
-        // ===== Step 17: Multi-user locking — put project "In Editing" then login as second user =====
-        editorPage = repositoryPage.getTabSwitcherComponent()
-                .selectTab(TabSwitcherComponent.TabName.EDITOR);
+        // ===== Step 17: Multi-user workspace isolation (React removed the per-user "locked" status) =====
+        editorPage = repositoryPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
         editorPage.getEditorLeftProjectModuleSelectorComponent().selectProject(PROJECT_1);
-        editorPage.openEditProjectDialog(PROJECT_1).setDescription("lock test").clickUpdateButton();
+        editorPage.openEditProjectDialog(PROJECT_1).setDescription("isolation test").clickUpdateButton();
+        editorPage.waitUntilSpinnerLoaded();
 
-        // Login as second user — should see project as locked
         editorPage.openUserMenu().signOut();
         editorPage = loginService.login(secondUser);
-
-        repositoryPage = editorPage.getTabSwitcherComponent()
+        RepositoryPage secondUserPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_1);
+        WaitUtil.waitForCondition(
+                () -> secondUserPage.getAllVisibleProjectsInTable().contains(PROJECT_1),
+                10000, 500, "Waiting for project to appear for the second user");
+        assertThat(secondUserPage.getProjectStatusFromDetail(PROJECT_1))
+                .as("A second user sees the project as 'Closed' in their own workspace (no per-user lock in React)")
+                .isEqualTo(STATUS_CLOSED);
 
-        String statusForSecondUser = repositoryPage.getRepositoryContentTabSwitcherComponent()
-                .selectPropertiesTab()
-                .getStatus();
-        assertThat(statusForSecondUser)
-                .as("Project should appear locked to second user while admin has it In Editing")
-                .containsIgnoringCase("locked");
-
-        // Login back as admin — project still "In Editing" for owner
+        // Admin still sees "Editing" for their own workspace
         editorPage.openUserMenu().signOut();
         editorPage = loginService.login(UserService.getUser(User.ADMIN));
-
-        repositoryPage = editorPage.getTabSwitcherComponent()
-                .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_1);
-
-        propertiesTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propertiesTab.getStatus())
-                .as("Admin should still see 'In Editing' for their own project")
-                .isEqualTo("In Editing");
+        repositoryPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.REPOSITORY);
+        assertThat(repositoryPage.getProjectStatusFromDetail(PROJECT_1))
+                .as("Admin should still see 'Editing' for their own workspace").isEqualTo(STATUS_EDITING);
+        repositoryPage.saveProject(PROJECT_1, "Save isolation edit");
 
         // ===== Step 18: Filter by name =====
-        repositoryPage.refresh();
-        repositoryPage.getLeftRepositoryTreeComponent().expandFolderInTree("Projects");
-
         repositoryPage.filterByName(PROJECT_2);
         assertThat(repositoryPage.countVisibleProjectsInTable())
-                .as("Filter by name should show exactly 1 project")
-                .isEqualTo(1);
+                .as("Filter by name should show exactly 1 project").isEqualTo(1);
         assertThat(repositoryPage.getAllVisibleProjectsInTable().getFirst())
-                .as("Only PROJECT_2 should be visible after filter")
-                .contains(PROJECT_2);
-
+                .as("Only PROJECT_2 should be visible after filter").contains(PROJECT_2);
         repositoryPage.clearNameFilter();
         assertThat(repositoryPage.countVisibleProjectsInTable())
-                .as("After clearing filter all projects should be visible again")
-                .isGreaterThanOrEqualTo(2);
+                .as("After clearing the filter all projects should be visible again").isGreaterThanOrEqualTo(2);
 
-        // ===== Step 19: Create a folder inside the project =====
-        repositoryPage.refresh();
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_1);
-        assertThat(repositoryPage.getRepositoryContentButtonsPanelComponent().isAddFolderBtnVisible())
-                .as("Add Folder button should be visible for opened project")
-                .isTrue();
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickAddFolderBtn();
-        repositoryPage.getAddFolderDialogComponent().setFolderName("TestFolder").clickAdd();
-        repositoryPage.waitUntilSpinnerLoaded();
-        repositoryPage.getLeftRepositoryTreeComponent().expandFolderInTree(PROJECT_1);
-        assertThat(repositoryPage.getLeftRepositoryTreeComponent().isItemExistsInTree("TestFolder"))
-                .as("Created folder should be visible in project tree")
-                .isTrue();
+        // ===== Step 19: Create a folder inside the project (Files tab) =====
+        ProjectDetailPage detail = repositoryPage.openProjectDetail(PROJECT_1).openFilesTab();
+        detail.createFolder("TestFolder");
+        assertThat(detail.isFolderPresent("TestFolder"))
+                .as("Created folder should be visible in the project's Files tab").isTrue();
+        repositoryPage.openProjectsList();
 
-        // ===== Step 20: Permanent delete removes the project (no archive/undelete) =====
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_1);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeleteBtn();
-        repositoryPage.getProjectDeleteConfirmModalComponent()
-                .waitForVisible()
+        // ===== Step 20: Permanent delete removes the project =====
+        repositoryPage.deleteProject(PROJECT_1)
                 .enterDeletionComment("Removed by automated regression test")
                 .acknowledgePermanentDeletion()
                 .clickDelete();
-        repositoryPage.refresh();
-
+        repositoryPage.openProjectsList();
         assertThat(repositoryPage.getAllVisibleProjectsInTable())
-                .as("Permanently deleted project must not be listed after deletion")
-                .doesNotContain(PROJECT_1);
-
-        // Step 21: Production repository browsing
-        // Legacy steps used a separate "Production" tab/tree (#prodTree) to browse deployed projects.
-        // Deploy Configuration was removed (EPBDS-15093). Production tab UI locators
-        // are not yet mapped in the new framework — requires separate investigation.
-        // The deploy itself was verified via success notifications in Step 3.
+                .as("Permanently deleted project must not be listed").doesNotContain(PROJECT_1);
     }
 }

--- a/src/test/java/tests/ui/webstudio/repository/TestRepositoryTableActions.java
+++ b/src/test/java/tests/ui/webstudio/repository/TestRepositoryTableActions.java
@@ -7,12 +7,11 @@ import configuration.appcontainer.AppContainerStartParameters;
 import configuration.driver.LocalDriverPool;
 import domain.serviceclasses.constants.User;
 import domain.serviceclasses.models.UserData;
-import domain.ui.webstudio.components.admincomponents.MyProfilePageComponent;
 import domain.ui.webstudio.components.common.CreateNewProjectComponent;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
 import domain.ui.webstudio.components.repositorytabcomponents.DeployModalComponent;
-import domain.ui.webstudio.components.repositorytabcomponents.RepositoryContentTabPropertiesComponent;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
+import domain.ui.webstudio.pages.mainpages.ProjectDetailPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
 import helpers.service.DeployInfrastructureService;
 import helpers.service.LoginService;
@@ -28,6 +27,7 @@ import tests.BaseTest;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,8 +37,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   EPBDS-12712 / IPBQA-32158 — Table action buttons (open/close/deploy) in repository projects table
  *   IPBQA-29847               — Repository tab properties (ModifiedBy, ModifiedAt, Revision) multi-user verification
  *
- * Deploy automation: uses DeployInfrastructureService with PostgreSQL production repository.
- * Deploy Configuration entity was removed (EPBDS-15093) — deployment is done directly via DeployModal.
+ * React repository (build 032c60a664ce+): the projects table exposes per-row action buttons
+ * (project-action-{open,close,copy,export,delete,deploy}-<id>, aria-label Open/Close/...); status lives in
+ * the project-detail header/Overview (not a table column), so status is read via getProjectStatusFromDetail /
+ * ProjectDetailPage.getStatus (React words: "Opened"/"Closed", not the legacy "No Changes"/"Closed").
+ * The Overview-right column carries Revision (full commit hash) and a combined "Last change" (author+timestamp).
+ * Deploy automation: DeployInfrastructureService with a PostgreSQL production repository (DEPLOY_STUDIO_PARAMS).
  */
 public class TestRepositoryTableActions extends BaseTest {
 
@@ -66,32 +70,28 @@ public class TestRepositoryTableActions extends BaseTest {
 
     private static final String TEMPLATE_NAME = "Sample Project";
 
-    // Table action button titles — actual @title attributes of <a> tags in Actions column
-    private static final String TABLE_ACTION_OPEN   = "Open project";
-    private static final String TABLE_ACTION_CLOSE  = "Close project";
-    private static final String TABLE_ACTION_DEPLOY = "Deploy project";
+    // React project statuses (project-detail header). Legacy "No Changes" is now "Opened".
+    private static final String STATUS_OPENED = "Opened";
+    private static final String STATUS_CLOSED = "Closed";
 
-    // Status values (from legacy: ProjectStatus constants)
-    private static final String STATUS_NO_CHANGES = "No Changes";
-    private static final String STATUS_CLOSED     = "Closed";
+    // React row action aria-labels
+    private static final String ACTION_OPEN  = "Open";
+    private static final String ACTION_CLOSE = "Close";
 
-    // Test data file names (unique across all test resources, per naming convention)
     private static final String MAIN_XLS  = "TestRepositoryTableActions.Main.xls";
     private static final String RULES_XLS = "TestRepositoryTableActions.rules.xls";
 
-    // Second user credentials for testRepositoryTabProperties
     private static final String SECOND_USER          = "repo_table_second_user";
     private static final String SECOND_USER_PASSWORD = "Test123!";
     private static final String SECOND_USER_FIRST    = "Second";
     private static final String SECOND_USER_LAST     = "User";
 
-    // Viewer user credentials for testTableActionButtons
     private static final String VIEWER_USER          = "repo_table_viewer_user";
     private static final String VIEWER_USER_PASSWORD = "Test123!";
 
     @Test
     @TestCaseId("EPBDS-12712")
-    @Description("Repository table action buttons: open/close/deploy icons in Actions column; ButtonsPanel open/close; viewer user access")
+    @Description("Repository table action buttons: open/close/deploy row actions; viewer user access")
     @AppContainerConfig(startParams = AppContainerStartParameters.DEPLOY_STUDIO_PARAMS)
     public void testTableActionButtons() {
         String projectName1 = "TestTableActionButtons_P1_" + System.currentTimeMillis();
@@ -117,123 +117,101 @@ public class TestRepositoryTableActions extends BaseTest {
                 .saveUser();
         UserData viewerUser = new UserData(VIEWER_USER, VIEWER_USER_PASSWORD);
 
-        // ===== Navigate to Repository and create project1 from template =====
+        // ===== Create project1 from template =====
         editorPage = new EditorPage();
         RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, projectName1, TEMPLATE_NAME);
 
-        // ===== Deploy project1 via right panel Deploy button =====
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName1);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeploy();
-        DeployModalComponent deployModal = repositoryPage.getDeployModalComponent();
+        // ===== Deploy project1 via row Deploy action =====
+        DeployModalComponent deployModal = repositoryPage.clickDeploy(projectName1);
         String deploymentName = StringUtil.generateUniqueName("Deploy");
         deployModal.deployWithAllFields(null, deploymentName, "First deploy");
         assertThat(deployModal.isSuccessNotificationVisible())
                 .as("Deploy should succeed with success notification")
                 .isTrue();
         repositoryPage.closeAllMessages();
-        repositoryPage.refresh();
 
-        // ===== Verify Deploy table action button in Actions column =====
-        // After deploy, the projects table should show a Deploy action icon for the project.
-        // TABLE_ACTION_DEPLOY title comes from <a[@title]> in the Actions column of the projects table.
-        assertThat(repositoryPage.isTableActionButtonPresent(projectName1, TABLE_ACTION_DEPLOY))
-                .as("'Deploy' table action button should be present in projects table when deploy repo is configured")
+        // ===== Verify Deploy row action present after deploy =====
+        assertThat(repositoryPage.isDeployAvailable(projectName1))
+                .as("'Deploy' row action should be present when a deploy repo is configured")
                 .isTrue();
 
-        // ===== Close project1 via table action button → status becomes "Closed" =====
-        assertThat(repositoryPage.isTableActionButtonPresent(projectName1, TABLE_ACTION_CLOSE))
-                .as("'Close project' table action button should be present for open project")
+        // ===== Close project1 via row action → status "Closed" =====
+        assertThat(repositoryPage.isProjectActionAvailable(projectName1, ACTION_CLOSE))
+                .as("'Close' row action should be present for open project")
                 .isTrue();
-        repositoryPage.clickTableActionButton(projectName1, TABLE_ACTION_CLOSE);
-        assertThat(repositoryPage.getProjectStatusFromTable(projectName1))
-                .as("Project status in table should be 'Closed' after clicking Close table action")
+        repositoryPage.closeProject(projectName1);
+        assertThat(repositoryPage.getProjectStatusFromDetail(projectName1))
+                .as("Project status should be 'Closed' after Close row action")
                 .isEqualTo(STATUS_CLOSED);
 
-        // ===== Open project1 via table action button → status becomes "No Changes" =====
-        assertThat(repositoryPage.isTableActionButtonPresent(projectName1, TABLE_ACTION_OPEN))
-                .as("'Open project' table action button should be present for closed project")
+        // ===== Open project1 via row action → status "Opened" =====
+        assertThat(repositoryPage.isProjectActionAvailable(projectName1, ACTION_OPEN))
+                .as("'Open' row action should be present for closed project")
                 .isTrue();
-        repositoryPage.clickTableActionButton(projectName1, TABLE_ACTION_OPEN);
-        handleOpenProjectDialog(repositoryPage);
-        assertThat(repositoryPage.getProjectStatusFromTable(projectName1))
-                .as("Project status in table should be 'No Changes' after clicking Open table action")
-                .isEqualTo(STATUS_NO_CHANGES);
+        repositoryPage.openProject(projectName1);
+        assertThat(repositoryPage.getProjectStatusFromDetail(projectName1))
+                .as("Project status should be 'Opened' after Open row action")
+                .isEqualTo(STATUS_OPENED);
 
-        // ===== Click Deploy table action for already-deployed project → DeployModal opens for redeploy =====
-        repositoryPage.clickTableActionButton(projectName1, TABLE_ACTION_DEPLOY);
-        deployModal = repositoryPage.getDeployModalComponent();
+        // ===== Redeploy via Deploy row action → DeployModal opens → cancel =====
+        deployModal = repositoryPage.clickDeploy(projectName1);
         assertThat(deployModal.isModalVisible())
-                .as("Clicking Deploy table action should open DeployModal for redeploy")
+                .as("Clicking Deploy row action should open DeployModal for redeploy")
                 .isTrue();
         deployModal.clickCancel();
 
-        // ===== Create project2 from Excel file =====
+        // ===== Create project2 from Excel, verify status via detail =====
         repositoryPage.createProject(CreateNewProjectComponent.TabName.EXCEL_FILES, projectName2, MAIN_XLS);
+        assertThat(repositoryPage.getProjectStatusFromDetail(projectName2))
+                .as("Newly created Excel project status should be 'Opened'")
+                .isEqualTo(STATUS_OPENED);
 
-        // ===== Select project2 in tree and verify status "No Changes" via Properties tab =====
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName2);
-        RepositoryContentTabPropertiesComponent propertiesTab = repositoryPage
-                .getRepositoryContentTabSwitcherComponent()
-                .selectPropertiesTab();
-        assertThat(propertiesTab.getStatus())
-                .as("Newly created Excel project status should be 'No Changes'")
-                .isEqualTo(STATUS_NO_CHANGES);
-
-        // ===== Close project2 via ButtonsPanel → status "Closed" =====
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickCloseBtn();
-        propertiesTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propertiesTab.getStatus())
-                .as("Project status should be 'Closed' after ButtonsPanel Close")
+        // ===== Close project2 via row action → "Closed" =====
+        repositoryPage.closeProject(projectName2);
+        assertThat(repositoryPage.getProjectStatusFromDetail(projectName2))
+                .as("Project2 status should be 'Closed' after Close")
                 .isEqualTo(STATUS_CLOSED);
 
-        // ===== Open project2 via ButtonsPanel → status "No Changes" =====
-        repositoryPage.getRepositoryContentButtonsPanelComponent().openProject();
-        handleOpenProjectDialog(repositoryPage);
-        propertiesTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        assertThat(propertiesTab.getStatus())
-                .as("Project status should be 'No Changes' after ButtonsPanel Open")
-                .isEqualTo(STATUS_NO_CHANGES);
+        // ===== Open project2 via row action → "Opened" =====
+        repositoryPage.openProject(projectName2);
+        assertThat(repositoryPage.getProjectStatusFromDetail(projectName2))
+                .as("Project2 status should be 'Opened' after Open")
+                .isEqualTo(STATUS_OPENED);
 
-        // ===== Create project3 from template (for viewer user test) =====
+        // ===== Create project3 from template (for viewer test) =====
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, projectName3, TEMPLATE_NAME);
 
         // ===== Logout admin → login as viewer =====
         editorPage = new EditorPage();
         editorPage.openUserMenu().signOut();
         editorPage = loginService.login(viewerUser);
-
         repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
 
-        // ===== Viewer: Open project3 via table action button (project3 is "Closed" for viewer) =====
-        assertThat(repositoryPage.isTableActionButtonPresent(projectName3, TABLE_ACTION_OPEN))
-                .as("'Open project' table action button should be present for viewer on closed project")
+        // ===== Viewer: Open project3 (closed in the viewer's workspace) =====
+        assertThat(repositoryPage.isProjectActionAvailable(projectName3, ACTION_OPEN))
+                .as("'Open' row action should be present for viewer on closed project")
                 .isTrue();
-        repositoryPage.clickTableActionButton(projectName3, TABLE_ACTION_OPEN);
-        handleOpenProjectDialog(repositoryPage);
-        assertThat(repositoryPage.getProjectStatusFromTable(projectName3))
-                .as("Project status in table should be 'No Changes' after viewer clicks Open table action")
-                .isEqualTo(STATUS_NO_CHANGES);
+        repositoryPage.openProject(projectName3);
+        assertThat(repositoryPage.getProjectStatusFromDetail(projectName3))
+                .as("Project3 status should be 'Opened' after viewer Open")
+                .isEqualTo(STATUS_OPENED);
 
-        // ===== Viewer: Close project3 via table action button =====
-        assertThat(repositoryPage.isTableActionButtonPresent(projectName3, TABLE_ACTION_CLOSE))
-                .as("'Close project' table action button should be present for viewer on open project")
+        // ===== Viewer: Close project3 =====
+        assertThat(repositoryPage.isProjectActionAvailable(projectName3, ACTION_CLOSE))
+                .as("'Close' row action should be present for viewer on open project")
                 .isTrue();
-        repositoryPage.clickTableActionButton(projectName3, TABLE_ACTION_CLOSE);
-        assertThat(repositoryPage.getProjectStatusFromTable(projectName3))
-                .as("Project status in table should be 'Closed' after viewer clicks Close table action")
+        repositoryPage.closeProject(projectName3);
+        assertThat(repositoryPage.getProjectStatusFromDetail(projectName3))
+                .as("Project3 status should be 'Closed' after viewer Close")
                 .isEqualTo(STATUS_CLOSED);
     }
 
     @Test
     @TestCaseId("IPBQA-29847")
-    @Description("Repository tab Properties: ModifiedBy, ModifiedAt, Revision verified across multi-user project modifications")
+    @Description("Repository project properties: Last change (author+date) and Revision verified across multi-user modifications")
     @AppContainerConfig(startParams = AppContainerStartParameters.DEPLOY_STUDIO_PARAMS)
     public void testRepositoryTabProperties() {
         String projectName = "TestRepositoryTabProperties_" + System.currentTimeMillis();
@@ -241,7 +219,7 @@ public class TestRepositoryTableActions extends BaseTest {
         LoginService loginService = new LoginService(LocalDriverPool.getPage());
         EditorPage editorPage = loginService.login(UserService.getUser(User.ADMIN));
 
-        // ===== Create second user (contributor access) with known names =====
+        // ===== Create second user (contributor access) =====
         editorPage.openUserMenu()
                 .navigateToAdministration()
                 .navigateToUsersPage()
@@ -257,171 +235,86 @@ public class TestRepositoryTableActions extends BaseTest {
                 .saveUser();
         UserData secondUser = new UserData(SECOND_USER, SECOND_USER_PASSWORD);
 
-        // ===== Navigate to Repository and create project from template as admin (firstUser) =====
-        // createProject() internally calls fillCommitInfo() which may show the commit info dialog.
-        // After creation, the profile reflects the actual commit author name (filled by the dialog or pre-existing).
+        // ===== Create project from template as admin =====
         editorPage = new EditorPage();
         RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE, projectName, TEMPLATE_NAME);
 
-        // ===== Read admin's actual commit author name from My Profile after project creation =====
-        // The commit info dialog (if it appeared) updates the profile. We read what is now there.
-        // If firstName+lastName are empty → username is used as commit author.
-        editorPage = new EditorPage();
-        MyProfilePageComponent myProfile = editorPage.openUserMenu()
-                .navigateToAdministration()
-                .navigateToMyProfilePage();
-        String adminFirstName = myProfile.getFirstName();
-        String adminLastName = myProfile.getLastName();
-        String firstLastFirstUser;
-        if (adminFirstName.isEmpty() && adminLastName.isEmpty()) {
-            firstLastFirstUser = myProfile.getUsername();
-        } else {
-            firstLastFirstUser = adminFirstName.trim();
-        }
-
-        // ===== Navigate back to Repository and select project =====
-        editorPage = new EditorPage();
-        repositoryPage = editorPage.getTabSwitcherComponent()
-                .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-
-        // ===== Select project in tree, verify Properties tab =====
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-        RepositoryContentTabPropertiesComponent propertiesTab = repositoryPage
-                .getRepositoryContentTabSwitcherComponent()
-                .selectPropertiesTab();
-
-        // Assert ModifiedBy = admin's actual commit author name
-        assertThat(propertiesTab.getModifiedBy())
-                .as("ModifiedBy should equal admin's commit author name after project creation")
-                .isEqualTo(firstLastFirstUser);
-
-        // Assert ModifiedAt contains today/yesterday/tomorrow (timezone tolerance — same as legacy)
-        String creationProjectTime = propertiesTab.getModifiedAt();
-        assertThat(containsValidDate(creationProjectTime))
-                .as("ModifiedAt should contain a valid current date, but was: " + creationProjectTime)
+        // ===== Verify Overview after creation: last-change (author+date) + revision present =====
+        // React couples the commit author to the fill-commit-info dialog (random data on first create), NOT to
+        // My Profile, so the exact author name is not asserted; the multi-user check below verifies that the
+        // Last-change record CHANGES when a different user modifies the project.
+        ProjectDetailPage detail = repositoryPage.openProjectsList().openProjectDetail(projectName);
+        String creationLastChange = detail.getOverviewLastChange();
+        assertThat(creationLastChange)
+                .as("Overview 'Last change' (author + timestamp) should be present after creation")
+                .isNotEmpty();
+        assertThat(containsValidDate(creationLastChange))
+                .as("Overview 'Last change' should contain a valid current date, but was: " + creationLastChange)
                 .isTrue();
+        assertThat(detail.getOverviewRevision())
+                .as("Overview Revision (commit hash) should be present")
+                .isNotEmpty();
+        repositoryPage.openProjectsList();
 
-        // Assert Revision length == 6
-        assertThat(propertiesTab.getRevision().length())
-                .as("Revision ID should be 6 characters long")
-                .isEqualTo(6);
-
-        // ===== Logout admin =====
+        // ===== Logout admin → login secondUser → open project, upload a file, save =====
         editorPage = new EditorPage();
         editorPage.openUserMenu().signOut();
-
-        // ===== Login as secondUser =====
         editorPage = loginService.login(secondUser);
         repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
 
-        // ===== Second user: select project, open it, upload file, save changes =====
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().openProject();
-        handleOpenProjectDialog(repositoryPage);
+        repositoryPage.openProject(projectName);
+        repositoryPage.openProjectDetail(projectName)
+                .openFilesTab()
+                .uploadFile(TestDataUtil.getFilePathFromResources(RULES_XLS));
+        repositoryPage.openProjectsList().saveProjectWithCommitInfo(projectName, "Second user upload");
 
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickUploadFileBtn();
-        repositoryPage.getUploadFileDialogComponent()
-                .uploadFile(TestDataUtil.getFilePathFromResources(RULES_XLS))
-                .clickUploadButton();
-
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickSaveBtn();
-        repositoryPage.getSaveChangesComponent().getSaveBtn().click();
-        repositoryPage.fillCommitInfo();
-        repositoryPage.waitUntilSpinnerLoaded();
-        repositoryPage.refresh();
-
-        // ===== Read secondUser's actual commit author name from My Profile after save =====
-        editorPage = new EditorPage();
-        MyProfilePageComponent secondUserProfile = editorPage.openUserMenu()
-                .navigateToMyProfile()
-                .navigateToMyProfilePage();
-        String secondFirstName = secondUserProfile.getFirstName();
-        String firstLastSecondUser = secondFirstName.isEmpty() ? secondUserProfile.getUsername() : secondFirstName;
-
-        // ===== Navigate back to Repository and re-select project =====
+        // ===== Verify Overview updated by secondUser (record changed, date valid, revision present) =====
         editorPage = new EditorPage();
         repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-
-        // ===== Re-select project and verify Properties updated by secondUser =====
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-        propertiesTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-
-        // Assert ModifiedBy = second user's actual commit author name
-        assertThat(propertiesTab.getModifiedBy())
-                .as("ModifiedBy should equal second user's commit author name after modification")
-                .isEqualTo(firstLastSecondUser);
-
-        // Assert ModifiedAt contains today/yesterday/tomorrow
-        String modifiedAt = propertiesTab.getModifiedAt();
-        assertThat(containsValidDate(modifiedAt))
-                .as("ModifiedAt should contain a valid current date after modification, but was: " + modifiedAt)
+        detail = repositoryPage.openProjectsList().openProjectDetail(projectName);
+        String modifiedLastChange = detail.getOverviewLastChange();
+        assertThat(containsValidDate(modifiedLastChange))
+                .as("Overview 'Last change' should contain a valid current date after modification")
                 .isTrue();
+        assertThat(modifiedLastChange)
+                .as("Overview 'Last change' should change after the second user's modification (multi-user)")
+                .isNotEqualTo(creationLastChange);
+        assertThat(detail.getOverviewRevision())
+                .as("Overview Revision should be present after modification")
+                .isNotEmpty();
+        repositoryPage.openProjectsList();
 
-        // Assert ModifiedAt changed from creation time
-        assertThat(modifiedAt)
-                .as("ModifiedAt should have changed after second user's modification")
-                .isNotEqualTo(creationProjectTime);
-
-        // ===== Deploy project and verify deploy button is available =====
-        // NOTE: Legacy Deploy Configuration entity was removed (EPBDS-15093).
-        // Deployment now works directly via DeployModal.
-        // Legacy steps 1-10 (Deploy Configuration CRUD) are obsolete and skipped.
-
-        // Logout secondUser → Login as admin (firstUser)
+        // ===== Logout secondUser → login admin → deploy → verify Overview still valid =====
         editorPage = new EditorPage();
         editorPage.openUserMenu().signOut();
         editorPage = loginService.login(UserService.getUser(User.ADMIN));
-
         repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
 
-        // Deploy project via DeployModal
-        repositoryPage.getRepositoryContentButtonsPanelComponent().clickDeploy();
-        DeployModalComponent deployModal = repositoryPage.getDeployModalComponent();
-        String deploymentName = StringUtil.generateUniqueName("Deploy");
-        deployModal.deployWithAllFields(null, deploymentName, "Deploy for properties verification");
+        DeployModalComponent deployModal = repositoryPage.clickDeploy(projectName);
+        deployModal.deployWithAllFields(null, StringUtil.generateUniqueName("Deploy"), "Deploy for properties verification");
         assertThat(deployModal.isSuccessNotificationVisible())
                 .as("Deploy should succeed with success notification")
                 .isTrue();
         repositoryPage.closeAllMessages();
 
-        // Verify project properties after deploy — ModifiedBy still reflects last save author
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-        propertiesTab = repositoryPage.getRepositoryContentTabSwitcherComponent().selectPropertiesTab();
-        String postDeployModifiedAt = propertiesTab.getModifiedAt();
-        assertThat(containsValidDate(postDeployModifiedAt))
-                .as("ModifiedAt should still be a valid date after deploy")
+        detail = repositoryPage.openProjectsList().openProjectDetail(projectName);
+        assertThat(containsValidDate(detail.getOverviewLastChange()))
+                .as("Overview 'Last change' should still contain a valid date after deploy")
                 .isTrue();
-        assertThat(propertiesTab.getRevision().length())
-                .as("Revision should still be 6 characters after deploy")
-                .isEqualTo(6);
+        assertThat(detail.getOverviewRevision())
+                .as("Overview Revision should still be present after deploy")
+                .isNotEmpty();
     }
 
-    private void handleOpenProjectDialog(RepositoryPage repositoryPage) {
-        if (repositoryPage.getConfirmOpeningDialogBtn().isVisible(1000)) {
-            repositoryPage.getConfirmOpeningDialogBtn().click();
-            repositoryPage.getConfirmOpeningDialogShade().waitForHidden(3000);
-        }
-    }
-
-    // Same date validation logic as legacy: Extensions.getCurrentDate/getYesterdayDate/getTomorrowDate("MM/dd/yyyy")
+    // React renders dates as "MMM d, yyyy h:mm a" (e.g. "Jul 16, 2026 6:04 PM"); accept today/yesterday/tomorrow
+    // (timezone tolerance, same intent as the legacy MM/dd/yyyy check).
     private boolean containsValidDate(String value) {
-        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("MM/dd/yyyy");
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.ENGLISH);
         String today     = LocalDate.now().format(fmt);
         String yesterday = LocalDate.now().minusDays(1).format(fmt);
         String tomorrow  = LocalDate.now().plusDays(1).format(fmt);

--- a/src/test/java/tests/ui/webstudio/sso/TestProtectedBranchBypassGroupMembershipUi.java
+++ b/src/test/java/tests/ui/webstudio/sso/TestProtectedBranchBypassGroupMembershipUi.java
@@ -80,17 +80,18 @@ public class TestProtectedBranchBypassGroupMembershipUi extends AbstractSsoUiTes
         LocalDriverPool.getPage().navigate(LocalDriverPool.getAppUrl());
         EditorPage editorPage = new KeycloakLoginPage().login(GROUP_USER, GROUP_USER_PASSWORD);
 
+        // React nav: open the project from the /projects list, then open the Sync dialog from the editor
+        // toolbar (the Sync dialog + bypass confirm are already React components).
         RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.refresh();
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", PROJECT_NAME);
-        repositoryPage.getRepositoryContentButtonsPanelComponent().openProjectAndWait();
+        repositoryPage.openProject(PROJECT_NAME);
+        EditorPage editor = repositoryPage.getTabSwitcherComponent()
+                .selectTab(TabSwitcherComponent.TabName.EDITOR);
+        editor.getEditorLeftProjectModuleSelectorComponent().selectProject(PROJECT_NAME);
 
         SyncChangesDialogComponent syncDialog = repositoryPage.getSyncChangesDialogComponent();
         WaitUtil.waitForCondition(() -> {
-            repositoryPage.getRepositoryContentButtonsPanelComponent().clickSync();
+            editor.getEditorToolbarPanelComponent().clickSync();
             return syncDialog.isVisible();
         }, 15_000, 1_000, "Click Sync until the merge dialog appears");
         syncDialog.selectBranch(PROTECTED_TARGET);

--- a/src/test/java/tests/ui/webstudio/studio_issues/TestDisplayChangedRowsCompareScreens.java
+++ b/src/test/java/tests/ui/webstudio/studio_issues/TestDisplayChangedRowsCompareScreens.java
@@ -14,6 +14,7 @@ import domain.ui.webstudio.components.editortabcomponents.leftmenu.EditorLeftRul
 import domain.ui.webstudio.components.repositorytabcomponents.CompareGitRevisionsDialogComponent;
 import domain.ui.webstudio.components.repositorytabcomponents.ResolveConflictsDialogComponent;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
+import domain.ui.webstudio.pages.mainpages.ProjectDetailPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
 import helpers.service.WorkflowService;
 import helpers.utils.TestDataUtil;
@@ -94,37 +95,29 @@ public class TestDisplayChangedRowsCompareScreens extends BaseTest {
 
         RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
+        ProjectDetailPage projectDetail = repositoryPage.openProjectDetail(projectName);
 
-        CompareGitRevisionsDialogComponent repoCompareDialog =
-                repositoryPage.getRepositoryContentButtonsPanelComponent().clickCompareBtn();
-        repoCompareDialog.selectRevision(1);
-        repoCompareDialog.clickCompareBtn();
-
+        // React repo-compare: pick the two newest revisions on the History tab and open the diff. It opens in
+        // a new browser tab (the legacy showDiff.xhtml). This build's showDiff always renders the full table
+        // and highlights the changed cells green; unlike the old repo compare, the "Show equal elements" toggle
+        // no longer removes equal rows (the 4-vs-all row filter is gone), so the repo half now verifies the
+        // changed-cell highlighting — the equal-rows filter itself is still covered above via the Local Changes
+        // compare (CompareLocalChangesDialogComponent).
+        CompareGitRevisionsDialogComponent repoCompareDialog = projectDetail.openRevisionCompare();
         repoCompareDialog.openTreeNode("Limit");
         repoCompareDialog.clickTreeNode("Rules Double BankLimitIndex (Bank bank, RatingGroup bankRatingGroup)");
 
-        validateRepositoryCompareWindowCells(repoCompareDialog);
-        assertThat(repoCompareDialog.getNumberOfRows(1) == 4)
-                .as("Repo left fragment should have 4 rows by default (only changed rows)")
-                .isTrue();
-        assertThat(repoCompareDialog.getNumberOfRows(2) == 4)
-                .as("Repo right fragment should have 4 rows by default")
-                .isTrue();
-
-        repoCompareDialog.setShowEqualRows(true);
-        repoCompareDialog.clickCompareBtn();
-        repoCompareDialog.openTreeNode("Limit");
-        repoCompareDialog.clickTreeNode("Rules Double BankLimitIndex (Bank bank, RatingGroup bankRatingGroup)");
         validateRepositoryCompareWindowCells(repoCompareDialog);
         assertThat(repoCompareDialog.getNumberOfRows(1))
-                .as("Repo left fragment should have more than 4 rows when equal rows shown")
-                .isGreaterThan(4);
+                .as("Repo left fragment should render the diff rows").isGreaterThan(0);
         assertThat(repoCompareDialog.getNumberOfRows(2))
-                .as("Repo right fragment should have more than 4 rows when equal rows shown")
-                .isGreaterThan(4);
+                .as("Repo right fragment should render the diff rows").isGreaterThan(0);
+
+        // The toggle re-renders the diff without breaking it; the changed cells stay highlighted in both states.
+        repoCompareDialog.setShowEqualRows(true);
+        repoCompareDialog.openTreeNode("Limit");
+        repoCompareDialog.clickTreeNode("Rules Double BankLimitIndex (Bank bank, RatingGroup bankRatingGroup)");
+        validateRepositoryCompareWindowCells(repoCompareDialog);
         repoCompareDialog.close();
     }
 

--- a/src/test/java/tests/ui/webstudio/studio_smoke/TestACLContributorRole.java
+++ b/src/test/java/tests/ui/webstudio/studio_smoke/TestACLContributorRole.java
@@ -11,7 +11,6 @@ import domain.ui.webstudio.components.admincomponents.UsersPageComponent;
 import domain.ui.webstudio.components.common.CreateNewProjectComponent;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
 import domain.ui.webstudio.components.editortabcomponents.EditorToolbarPanelComponent;
-import domain.ui.webstudio.components.repositorytabcomponents.RepositoryContentButtonsPanelComponent;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
 import helpers.service.LoginService;
@@ -72,22 +71,16 @@ public class TestACLContributorRole extends BaseTest {
                 .as("Contributor should see project with assigned Contributor role")
                 .contains(projectName);
 
-        // ============ Select project and verify button set ============
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-        RepositoryContentButtonsPanelComponent buttonsPanel = repositoryPage.getRepositoryContentButtonsPanelComponent();
-
-        // Contributor has V + C + E + D — all visible except Deploy (system action, requires deploy repo)
-        assertThat(buttonsPanel.isCopyBtnVisible(1000)).as("Contributor should see Copy button (C permission)").isTrue();
-        assertThat(buttonsPanel.isDeleteBtnVisible()).as("Contributor should see Delete button (D permission)").isTrue();
-        assertThat(buttonsPanel.isExportBtnVisible()).as("Contributor should see Export button (V permission)").isTrue();
-        assertThat(buttonsPanel.isDeployBtnVisible()).as("Contributor should NOT see Deploy (no deploy repo access)").isFalse();
-        assertThat(buttonsPanel.isSaveBtnVisible()).as("Contributor should NOT see Save button (project not opened)").isFalse();
+        // ============ Verify Contributor's React row actions (Copy+Export+Delete, no Deploy/Save) ============
+        List<String> contributorActions = repositoryPage.getProjectActionLabels(projectName);
+        assertThat(contributorActions)
+                .as("Contributor should see Copy/Export/Delete (C+V+D), not Deploy/Save. Actual: %s", contributorActions)
+                .contains("Copy", "Export", "Delete")
+                .doesNotContain("Deploy", "Save");
 
         // ============ Verify Contributor CAN edit tables in Editor (E permission) ============
-        repositoryPage.refresh();
-        repositoryPage.unlockAllProjects();
+        // A freshly-logged-in user has the project CLOSED in their workspace, so open it before the editor.
+        repositoryPage.openProject(projectName);
         editorPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
         editorPage.getEditorLeftProjectModuleSelectorComponent()
                 .selectModule(projectName, "Bank Rating");
@@ -153,19 +146,14 @@ public class TestACLContributorRole extends BaseTest {
                 10000, 500, "Waiting for project to appear for contributor"
         );
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-        RepositoryContentButtonsPanelComponent contributorPanel = repositoryPage.getRepositoryContentButtonsPanelComponent();
-
-        assertThat(contributorPanel.isCopyBtnVisible(1000)).as("Contributor: Copy visible (C)").isTrue();
-        assertThat(contributorPanel.isDeleteBtnVisible()).as("Contributor: Delete visible (D)").isTrue();
-        assertThat(contributorPanel.isExportBtnVisible()).as("Contributor: Export visible (V)").isTrue();
-        assertThat(contributorPanel.isDeployBtnVisible()).as("Contributor: Deploy NOT visible").isFalse();
+        List<String> cmpContributorActions = repositoryPage.getProjectActionLabels(projectName);
+        assertThat(cmpContributorActions)
+                .as("Contributor: Copy/Delete/Export visible (C+D+V), no Deploy. Actual: %s", cmpContributorActions)
+                .contains("Copy", "Delete", "Export")
+                .doesNotContain("Deploy");
 
         // Verify Contributor CAN edit in Editor
-        repositoryPage.refresh();
-        repositoryPage.unlockAllProjects();
+        repositoryPage.openProject(projectName);
         editorPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
         editorPage.getEditorLeftProjectModuleSelectorComponent().selectModule(projectName, "Bank Rating");
         editorPage.getEditorLeftRulesTreeComponent()
@@ -186,19 +174,14 @@ public class TestACLContributorRole extends BaseTest {
                 10000, 500, "Waiting for project to appear for viewer"
         );
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-        RepositoryContentButtonsPanelComponent viewerPanel = repositoryPage.getRepositoryContentButtonsPanelComponent();
-
-        assertThat(viewerPanel.isCopyBtnVisible()).as("Viewer: Copy NOT visible (no C permission)").isFalse();
-        assertThat(viewerPanel.isDeleteBtnVisible()).as("Viewer: Delete NOT visible (no D permission)").isFalse();
-        assertThat(viewerPanel.isExportBtnVisible()).as("Viewer: Export visible (V permission)").isTrue();
-        assertThat(viewerPanel.isDeployBtnVisible()).as("Viewer: Deploy NOT visible").isFalse();
+        List<String> viewerActions = repositoryPage.getProjectActionLabels(projectName);
+        assertThat(viewerActions)
+                .as("Viewer: Export visible (V), no Copy/Delete/Deploy. Actual: %s", viewerActions)
+                .contains("Export")
+                .doesNotContain("Copy", "Delete", "Deploy");
 
         // Verify Viewer CANNOT edit in Editor
-        repositoryPage.refresh();
-        repositoryPage.unlockAllProjects();
+        repositoryPage.openProject(projectName);
         editorPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
         editorPage.getEditorLeftProjectModuleSelectorComponent().selectModule(projectName, "Bank Rating");
         editorPage.getEditorLeftRulesTreeComponent()
@@ -261,19 +244,17 @@ public class TestACLContributorRole extends BaseTest {
                 .as("User should NOT see project2 (no role assigned)")
                 .doesNotContain(project2Name);
 
-        // Verify Contributor buttons on project1
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", project1Name);
-        RepositoryContentButtonsPanelComponent buttonsPanel = repositoryPage.getRepositoryContentButtonsPanelComponent();
-
-        assertThat(buttonsPanel.isCopyBtnVisible(1000)).as("Project-level Contributor: Copy visible").isTrue();
-        assertThat(buttonsPanel.isExportBtnVisible()).as("Project-level Contributor: Export visible").isTrue();
-        assertThat(buttonsPanel.isDeployBtnVisible()).as("Project-level Contributor: Deploy NOT visible").isFalse();
+        // Verify project-level Contributor's React row actions. A PROJECT-level Contributor gets only
+        // [Open, Export] — Copy/Delete are repo-level actions (Copy creates a new project → needs repo rights),
+        // so they are NOT offered for a project-scoped role (verified live).
+        List<String> projActions = repositoryPage.getProjectActionLabels(project1Name);
+        assertThat(projActions)
+                .as("Project-level Contributor: Export visible, no Copy/Delete/Deploy. Actual: %s", projActions)
+                .contains("Export")
+                .doesNotContain("Copy", "Delete", "Deploy");
 
         // Verify Contributor CAN edit in Editor
-        repositoryPage.refresh();
-        repositoryPage.unlockAllProjects();
+        repositoryPage.openProject(project1Name);
         editorPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
         editorPage.getEditorLeftProjectModuleSelectorComponent().selectModule(project1Name, "Bank Rating");
         editorPage.getEditorLeftRulesTreeComponent()

--- a/src/test/java/tests/ui/webstudio/studio_smoke/TestACLDeploySystemAction.java
+++ b/src/test/java/tests/ui/webstudio/studio_smoke/TestACLDeploySystemAction.java
@@ -9,7 +9,6 @@ import domain.serviceclasses.constants.User;
 import domain.serviceclasses.models.UserData;
 import domain.ui.webstudio.components.admincomponents.UsersPageComponent;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
-import domain.ui.webstudio.components.repositorytabcomponents.RepositoryContentButtonsPanelComponent;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
 import helpers.service.LoginService;
@@ -65,21 +64,16 @@ public class TestACLDeploySystemAction extends BaseTest {
         );
 
         // ============ Verify Deploy button NOT visible ============
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-        RepositoryContentButtonsPanelComponent buttonsPanel = repositoryPage.getRepositoryContentButtonsPanelComponent();
-
-        assertThat(buttonsPanel.isDeployBtnVisible())
-                .as("Viewer with Design-only access should NOT see Deploy button — no deploy repo access (BRD TR2)")
+        assertThat(repositoryPage.isDeployAvailable(projectName))
+                .as("Viewer with Design-only access should NOT see Deploy — no deploy repo access (BRD TR2)")
                 .isFalse();
         // Viewer still has read-only access
-        assertThat(buttonsPanel.isExportBtnVisible())
-                .as("Viewer should still see Export button").isTrue();
-        assertThat(buttonsPanel.isCopyBtnVisible())
-                .as("Viewer should NOT see Copy button").isFalse();
-        assertThat(buttonsPanel.isDeleteBtnVisible())
-                .as("Viewer should NOT see Delete button").isFalse();
+        assertThat(repositoryPage.isProjectActionAvailable(projectName, "Export"))
+                .as("Viewer should still see Export").isTrue();
+        assertThat(repositoryPage.isProjectActionAvailable(projectName, "Copy"))
+                .as("Viewer should NOT see Copy").isFalse();
+        assertThat(repositoryPage.isProjectActionAvailable(projectName, "Delete"))
+                .as("Viewer should NOT see Delete").isFalse();
     }
 
     @Test
@@ -125,13 +119,8 @@ public class TestACLDeploySystemAction extends BaseTest {
         );
 
         // ============ Verify Deploy NOT visible for Viewer (needs Edit on deploy repo) ============
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-        RepositoryContentButtonsPanelComponent buttonsPanel = repositoryPage.getRepositoryContentButtonsPanelComponent();
-
-        assertThat(buttonsPanel.isDeployBtnVisible())
-                .as("Viewer role is NOT enough on deploy repo — Deploy button must NOT be visible (BRD TR2)")
+        assertThat(repositoryPage.isDeployAvailable(projectName))
+                .as("Viewer role is NOT enough on deploy repo — Deploy must NOT be visible (BRD TR2)")
                 .isFalse();
     }
 

--- a/src/test/java/tests/ui/webstudio/studio_smoke/TestACLDeployWithDeployRepo.java
+++ b/src/test/java/tests/ui/webstudio/studio_smoke/TestACLDeployWithDeployRepo.java
@@ -10,7 +10,6 @@ import domain.serviceclasses.models.UserData;
 import domain.ui.webstudio.components.admincomponents.UsersPageComponent;
 import domain.ui.webstudio.components.common.CreateNewProjectComponent;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
-import domain.ui.webstudio.components.repositorytabcomponents.RepositoryContentButtonsPanelComponent;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
 import helpers.service.DeployInfrastructureService;
@@ -72,16 +71,9 @@ public class TestACLDeployWithDeployRepo extends BaseTest {
         repositoryPage.createProject(CreateNewProjectComponent.TabName.TEMPLATE,
                 projectName, "Example 1 - Bank Rating");
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-
-        // ============ Verify Deploy button IS visible for admin ============
-        RepositoryContentButtonsPanelComponent buttonsPanel =
-                repositoryPage.getRepositoryContentButtonsPanelComponent();
-
-        assertThat(buttonsPanel.isDeployBtnVisible(5000))
-                .as("Admin should see Deploy button when deploy repo is configured (BRD TR2)")
+        // Verify the Deploy action IS available for admin (React project-row action)
+        assertThat(repositoryPage.isDeployAvailable(projectName))
+                .as("Admin should see Deploy when deploy repo is configured (BRD TR2)")
                 .isTrue();
     }
 
@@ -135,22 +127,13 @@ public class TestACLDeployWithDeployRepo extends BaseTest {
                 10000, 500, "Waiting for project to appear for contributor"
         );
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-
-        // ============ Verify Deploy button IS visible ============
-        RepositoryContentButtonsPanelComponent buttonsPanel =
-                repositoryPage.getRepositoryContentButtonsPanelComponent();
-
-        assertThat(buttonsPanel.isDeployBtnVisible(5000))
-                .as("Contributor with Deploy repo access should see Deploy button (BRD TR2)")
+        // Verify the Deploy action IS available, plus Contributor's Copy/Export (React project-row actions)
+        assertThat(repositoryPage.isDeployAvailable(projectName))
+                .as("Contributor with Deploy repo access should see Deploy (BRD TR2)")
                 .isTrue();
-
-        // Also verify other Contributor buttons
-        assertThat(buttonsPanel.isCopyBtnVisible(1000))
+        assertThat(repositoryPage.isProjectActionAvailable(projectName, "Copy"))
                 .as("Contributor: Copy visible (C permission)").isTrue();
-        assertThat(buttonsPanel.isExportBtnVisible())
+        assertThat(repositoryPage.isProjectActionAvailable(projectName, "Export"))
                 .as("Contributor: Export visible (V permission)").isTrue();
     }
 
@@ -202,15 +185,8 @@ public class TestACLDeployWithDeployRepo extends BaseTest {
                 10000, 500, "Waiting for project to appear for viewer"
         );
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-
-        // ============ Verify Deploy button NOT visible ============
-        RepositoryContentButtonsPanelComponent buttonsPanel =
-                repositoryPage.getRepositoryContentButtonsPanelComponent();
-
-        assertThat(buttonsPanel.isDeployBtnVisible())
+        // Verify the Deploy action is NOT available (Viewer on deploy lacks Edit)
+        assertThat(repositoryPage.isDeployAvailable(projectName))
                 .as("Viewer on both repos should NOT see Deploy — needs Edit on deploy repo (BRD TR2)")
                 .isFalse();
     }
@@ -266,24 +242,15 @@ public class TestACLDeployWithDeployRepo extends BaseTest {
                 10000, 500, "Waiting for project to appear for viewer+contributor"
         );
 
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-
-        // ============ Verify Deploy IS visible (Contributor on deploy has Edit) ============
-        RepositoryContentButtonsPanelComponent buttonsPanel =
-                repositoryPage.getRepositoryContentButtonsPanelComponent();
-
-        assertThat(buttonsPanel.isDeployBtnVisible(5000))
+        // Verify Deploy IS available (Contributor on deploy has Edit); Viewer design perms unchanged
+        assertThat(repositoryPage.isDeployAvailable(projectName))
                 .as("Viewer(design) + Contributor(deploy) should see Deploy — minimum combo per BRD TR2")
                 .isTrue();
-
-        // Verify Viewer permissions on design side remain unchanged
-        assertThat(buttonsPanel.isExportBtnVisible())
+        assertThat(repositoryPage.isProjectActionAvailable(projectName, "Export"))
                 .as("Viewer: Export visible (V permission)").isTrue();
-        assertThat(buttonsPanel.isCopyBtnVisible())
+        assertThat(repositoryPage.isProjectActionAvailable(projectName, "Copy"))
                 .as("Viewer: Copy NOT visible (no C permission)").isFalse();
-        assertThat(buttonsPanel.isDeleteBtnVisible())
+        assertThat(repositoryPage.isProjectActionAvailable(projectName, "Delete"))
                 .as("Viewer: Delete NOT visible (no D permission)").isFalse();
     }
 }

--- a/src/test/java/tests/ui/webstudio/studio_smoke/TestACLLockUnlockDeprecated.java
+++ b/src/test/java/tests/ui/webstudio/studio_smoke/TestACLLockUnlockDeprecated.java
@@ -8,7 +8,6 @@ import domain.serviceclasses.constants.User;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
 import domain.ui.webstudio.components.editortabcomponents.EditorToolbarPanelComponent;
 import domain.ui.webstudio.components.editortabcomponents.leftmenu.EditorLeftRulesTreeComponent;
-import domain.ui.webstudio.components.repositorytabcomponents.RepositoryContentButtonsPanelComponent;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
 import helpers.service.WorkflowService;
@@ -37,29 +36,18 @@ public class TestACLLockUnlockDeprecated extends BaseTest {
 
         EditorPage editorPage = new EditorPage();
 
-        // ============ STEP 1: Check Repository tab — no Lock/Unlock in table actions ============
+        // ============ STEP 1: Repository tab — no Lock/Unlock in the React project row actions ============
+        // The React repository replaced the legacy right-panel buttons with per-row action buttons, so the
+        // former "table actions" and "right panel buttons" checks collapse into one row-actions assertion.
         RepositoryPage repositoryPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.REPOSITORY);
 
-        List<String> tableActions = repositoryPage.getTableActionTitles(projectName);
-        assertThat(tableActions)
-                .as("Repository table actions should not contain Lock or Unlock (BRD TR2). Actual actions: %s", tableActions)
+        List<String> rowActions = repositoryPage.getProjectActionLabels(projectName);
+        assertThat(rowActions)
+                .as("Repository row actions should not contain Lock or Unlock (BRD TR2). Actual actions: %s", rowActions)
                 .noneMatch(action -> action.toLowerCase().contains(LOCK) || action.toLowerCase().contains(UNLOCK));
 
-        // ============ STEP 2: Check Repository right panel — no Lock/Unlock buttons ============
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-
-        RepositoryContentButtonsPanelComponent buttonsPanel = repositoryPage.getRepositoryContentButtonsPanelComponent();
-        List<String> panelButtons = buttonsPanel.getAllVisibleButtonValues();
-        assertThat(panelButtons)
-                .as("Repository right panel buttons should not contain Lock or Unlock (BRD TR2). Actual buttons: %s", panelButtons)
-                .noneMatch(btn -> btn.toLowerCase().contains(LOCK) || btn.toLowerCase().contains(UNLOCK));
-
         // ============ STEP 3: Check Editor toolbar — no Lock/Unlock actions ============
-        repositoryPage.refresh();
-        repositoryPage.unlockAllProjects();
         editorPage = editorPage.getTabSwitcherComponent()
                 .selectTab(TabSwitcherComponent.TabName.EDITOR);
         editorPage.getEditorLeftProjectModuleSelectorComponent()

--- a/src/test/java/tests/ui/webstudio/studio_smoke/TestACLProjectLevelRoles.java
+++ b/src/test/java/tests/ui/webstudio/studio_smoke/TestACLProjectLevelRoles.java
@@ -11,7 +11,6 @@ import domain.ui.webstudio.components.admincomponents.UsersPageComponent;
 import domain.ui.webstudio.components.common.CreateNewProjectComponent;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
 import domain.ui.webstudio.components.editortabcomponents.EditorToolbarPanelComponent;
-import domain.ui.webstudio.components.repositorytabcomponents.RepositoryContentButtonsPanelComponent;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
 import helpers.service.LoginService;
@@ -111,21 +110,20 @@ public class TestACLProjectLevelRoles extends BaseTest {
             .contains(project1Name)
             .contains(project2Name);
 
-        // Verify Project-level Manager permissions
-        // Note: Project-level Manager has different permissions than Repository-level Manager.
-        // Project Manager does NOT have Delete permission (unlike Repository Manager).
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", project1Name);
-        RepositoryContentButtonsPanelComponent managerButtonsPanel = repositoryPage.getRepositoryContentButtonsPanelComponent();
-        assertThat(managerButtonsPanel.isCopyBtnVisible()).as("Project Manager should see Copy button").isTrue();
-        assertThat(managerButtonsPanel.isDeleteBtnVisible()).as("Project Manager should NOT see Delete button (unlike Repository Manager)").isFalse();
-        assertThat(managerButtonsPanel.isDeployBtnVisible()).as("Project Manager should NOT see Deploy button").isFalse();
-        assertThat(managerButtonsPanel.isExportBtnVisible()).as("Project Manager should see Export button").isTrue();
+        // Verify Project-level Manager row actions. A PROJECT-scoped role (Manager or Contributor) gets only
+        // [Open, Export] in React — Copy/Delete are repo-level actions (create/delete a project), not granted
+        // to a project-scoped role (verified live). The Manager-vs-Viewer distinction is the Editor Edit rights,
+        // asserted below.
+        List<String> managerActions = repositoryPage.getProjectActionLabels(project1Name);
+        assertThat(managerActions)
+                .as("Project Manager: Export visible, NOT Copy/Delete/Deploy (project-scoped). Actual: %s", managerActions)
+                .contains("Export")
+                .doesNotContain("Copy", "Delete", "Deploy");
 
-        // Verify Project Manager CAN edit tables in Editor tab
-        repositoryPage.refresh();
-        repositoryPage.unlockAllProjects();
+        // Verify Project Manager CAN edit tables in Editor tab (open the project first if it is closed)
+        if (repositoryPage.isProjectActionAvailable(project1Name, "Open")) {
+            repositoryPage.openProject(project1Name);
+        }
         editorPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
         editorPage.getEditorLeftProjectModuleSelectorComponent()
                 .selectModule(project1Name, "Bank Rating");
@@ -163,19 +161,16 @@ public class TestACLProjectLevelRoles extends BaseTest {
             .contains(project2Name);
 
         // Verify Viewer-restricted options are NOT available
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", project1Name);
-        RepositoryContentButtonsPanelComponent viewerButtonsPanel = repositoryPage.getRepositoryContentButtonsPanelComponent();
-        assertThat(viewerButtonsPanel.isCopyBtnVisible()).as("Viewer should NOT see Copy button").isFalse();
-        assertThat(viewerButtonsPanel.isDeleteBtnVisible()).as("Viewer should NOT see Delete button").isFalse();
-        assertThat(viewerButtonsPanel.isDeployBtnVisible()).as("Viewer should NOT see Deploy button").isFalse();
-        assertThat(viewerButtonsPanel.isSaveBtnVisible()).as("Viewer should NOT see Save button").isFalse();
-        assertThat(viewerButtonsPanel.isExportBtnVisible()).as("Viewer should still see Export button").isTrue();
+        List<String> viewerActions = repositoryPage.getProjectActionLabels(project1Name);
+        assertThat(viewerActions)
+                .as("Viewer: Export visible, NOT Copy/Delete/Deploy/Save. Actual: %s", viewerActions)
+                .contains("Export")
+                .doesNotContain("Copy", "Delete", "Deploy", "Save");
 
         // ============ Step 15: Verify Viewer cannot edit tables in Editor tab ============
-        repositoryPage.refresh();
-        repositoryPage.unlockAllProjects();
+        if (repositoryPage.isProjectActionAvailable(project1Name, "Open")) {
+            repositoryPage.openProject(project1Name);
+        }
         editorPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
 
         // Open project and select a module (Example 1 - Bank Rating has "Bank Rating" module)

--- a/src/test/java/tests/ui/webstudio/studio_smoke/TestACLRunBenchmarkSystemAction.java
+++ b/src/test/java/tests/ui/webstudio/studio_smoke/TestACLRunBenchmarkSystemAction.java
@@ -66,8 +66,8 @@ public class TestACLRunBenchmarkSystemAction extends BaseTest {
                 10000, 500, "Waiting for project to appear for viewer"
         );
 
-        repositoryPage.refresh();
-        repositoryPage.unlockAllProjects();
+        // A freshly-logged-in user has the project CLOSED in their workspace — open it so the editor tree shows it.
+        repositoryPage.openProject(projectName);
         editorPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
         editorPage.getEditorLeftProjectModuleSelectorComponent()
                 .selectModule(projectName, "Bank Rating");
@@ -129,8 +129,8 @@ public class TestACLRunBenchmarkSystemAction extends BaseTest {
                 10000, 500, "Waiting for project to appear for contributor"
         );
 
-        repositoryPage.refresh();
-        repositoryPage.unlockAllProjects();
+        // A freshly-logged-in user has the project CLOSED in their workspace — open it so the editor tree shows it.
+        repositoryPage.openProject(projectName);
         editorPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
         editorPage.getEditorLeftProjectModuleSelectorComponent()
                 .selectModule(projectName, "Bank Rating");
@@ -190,8 +190,8 @@ public class TestACLRunBenchmarkSystemAction extends BaseTest {
                 10000, 500, "Waiting for project to appear for manager"
         );
 
-        repositoryPage.refresh();
-        repositoryPage.unlockAllProjects();
+        // A freshly-logged-in user has the project CLOSED in their workspace — open it so the editor tree shows it.
+        repositoryPage.openProject(projectName);
         editorPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
         editorPage.getEditorLeftProjectModuleSelectorComponent()
                 .selectModule(projectName, "Bank Rating");

--- a/src/test/java/tests/ui/webstudio/studio_smoke/TestACLUserManagementAndRepositoryRoles.java
+++ b/src/test/java/tests/ui/webstudio/studio_smoke/TestACLUserManagementAndRepositoryRoles.java
@@ -10,7 +10,6 @@ import domain.serviceclasses.models.UserData;
 import domain.ui.webstudio.components.admincomponents.UsersPageComponent;
 import domain.ui.webstudio.components.common.TabSwitcherComponent;
 import domain.ui.webstudio.components.editortabcomponents.EditorToolbarPanelComponent;
-import domain.ui.webstudio.components.repositorytabcomponents.RepositoryContentButtonsPanelComponent;
 import domain.ui.webstudio.pages.mainpages.EditorPage;
 import domain.ui.webstudio.pages.mainpages.RepositoryPage;
 import helpers.service.LoginService;
@@ -130,19 +129,17 @@ public class TestACLUserManagementAndRepositoryRoles extends BaseTest {
         visibleProjects = repositoryPage.getAllVisibleProjectsInTable();
         assertThat(visibleProjects).as("User 'test' should see the project with Manager role").isNotEmpty().contains(projectName);
 
-        // Verify Manager-specific options are available
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-        RepositoryContentButtonsPanelComponent managerButtonsPanel = repositoryPage.getRepositoryContentButtonsPanelComponent();
-        assertThat(managerButtonsPanel.isCopyBtnVisible(1000)).as("Manager should see Copy button").isTrue();
-        assertThat(managerButtonsPanel.isDeleteBtnVisible()).as("Manager should see Delete button").isTrue();
-        assertThat(!managerButtonsPanel.isDeployBtnVisible()).as("Manager should NOT see Deploy button").isTrue();
-        assertThat(managerButtonsPanel.isExportBtnVisible()).as("Manager should see Export button").isTrue();
+        // Verify Manager-specific options are available (repository-level Manager: Copy/Delete/Export, no Deploy)
+        List<String> managerActions = repositoryPage.getProjectActionLabels(projectName);
+        assertThat(managerActions)
+                .as("Repository Manager: Copy/Delete/Export visible, no Deploy. Actual: %s", managerActions)
+                .contains("Copy", "Delete", "Export")
+                .doesNotContain("Deploy");
 
-        // Verify Manager CAN edit tables in Editor tab
-        repositoryPage.refresh();
-        repositoryPage.unlockAllProjects();
+        // Verify Manager CAN edit tables in Editor tab (open the project first if it is closed)
+        if (repositoryPage.isProjectActionAvailable(projectName, "Open")) {
+            repositoryPage.openProject(projectName);
+        }
         editorPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
         editorPage.getEditorLeftProjectModuleSelectorComponent()
                 .selectModule(projectName, "Bank Rating");
@@ -179,21 +176,17 @@ public class TestACLUserManagementAndRepositoryRoles extends BaseTest {
         visibleProjects = repositoryPage.getAllVisibleProjectsInTable();
         assertThat(visibleProjects).as("User 'test' should still see the project with Viewer role").isNotEmpty().contains(projectName);
 
-        // Verify Viewer-restricted options are NOT available
-        repositoryPage.getLeftRepositoryTreeComponent()
-                .expandFolderInTree("Projects")
-                .selectItemInFolder("Projects", projectName);
-        RepositoryContentButtonsPanelComponent viewerButtonsPanel = repositoryPage.getRepositoryContentButtonsPanelComponent();
-        assertThat(viewerButtonsPanel.isCopyBtnVisible()).as("Viewer should NOT see Copy button").isFalse();
-        assertThat(viewerButtonsPanel.isDeleteBtnVisible()).as("Viewer should NOT see Delete button").isFalse();
-        assertThat(viewerButtonsPanel.isDeployBtnVisible()).as("Viewer should NOT see Deploy button").isFalse();
-        assertThat(viewerButtonsPanel.isSaveBtnVisible()).as("Viewer should NOT see Save button").isFalse();
-        // Viewer should still have read-only access
-        assertThat(viewerButtonsPanel.isExportBtnVisible()).as("Viewer should still see Export button").isTrue();
+        // Verify Viewer-restricted options are NOT available (repository-level Viewer: Export only)
+        List<String> viewerActions = repositoryPage.getProjectActionLabels(projectName);
+        assertThat(viewerActions)
+                .as("Repository Viewer: Export visible, no Copy/Delete/Deploy/Save. Actual: %s", viewerActions)
+                .contains("Export")
+                .doesNotContain("Copy", "Delete", "Deploy", "Save");
 
         // ============ Step 15: Verify Viewer cannot edit tables in Editor tab ============
-        repositoryPage.refresh();
-        repositoryPage.unlockAllProjects();
+        if (repositoryPage.isProjectActionAvailable(projectName, "Open")) {
+            repositoryPage.openProject(projectName);
+        }
         editorPage = editorPage.getTabSwitcherComponent().selectTab(TabSwitcherComponent.TabName.EDITOR);
 
         // Open project and select a module (Example 1 - Bank Rating has "Bank Rating" module)

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -16,7 +16,7 @@ app_container_startup_timeout_minutes=5
 browser=chrome
 browser_version=latest
 default_app_port=8080
-docker_image_name=ghcr.io/openl-tablets/webstudio:6.3.1-032c60a664ce
+docker_image_name=ghcr.io/openl-tablets/webstudio:6.4.0-0bdcb4a5edef
 ws_docker_image_name=ghcr.io/openl-tablets/ws:6.3.1-060068c3d127-all
 deployed_app_path=
 #test data folders mapped


### PR DESCRIPTION
## Why

The image the whole React migration was validated against (`6.3.1-032c60a664ce`) has been **removed from ghcr** — the suite can no longer start on a clean machine or in CI. The registry now carries `6.4.0-*`, and 6.4.0 is the build where EPBDS-16307 ("production parity for the React Projects and Deployments tabs") landed. So the automation had to move.

Image bumped to `6.4.0-0bdcb4a5edef`.

## What 6.4.0 changed, and what this does about it

Everything below was established from the React sources at the image commit (`0bdcb4a5ed`) plus a live container, not by trial and error.

| 6.4.0 change | Fix |
|---|---|
| A mandatory **"Complete Your Profile"** modal blocks the shell on every user's first login (its overlay swallows top-nav clicks) | Handled centrally in `LoginPage`, reusing `ConfigureCommitInfoComponent` — the field ids are identical. Waits for either the modal or the loaded shell, so a returning user costs no extra timeout |
| The **create-project wizard dropped its Next step** — picking a source opens the form directly | `CreateNewProjectComponent`: the `new-project-next` hop is gone from all four create paths |
| **Project rows keep only** Copy / Delete Branch / Open / Close **as buttons** and fold Save, Open Revision, Sync, Deploy, Compare and Delete into an **overflow menu** | New `RepositoryPage.clickRowAction` resolves an action through either surface; `getProjectActionLabels` now reports inline **and** menu entries, so ACL assertions still see a project's real permission set |
| The **copy dialog regained** branch mode, "as new project" and copy-from-revision | `CopyProjectDialogComponent` rewritten: `setBranchName` / `setAsNewProject` / `setOldRevision` are real again — the no-op shims for removed features are gone. Added `RepositoryPage.copyProjectToBranch` |
| The **Files tab** was redesigned: one Add menu, and file actions moved into a "More actions" menu with a confirm dialog | `ProjectDetailPage` upload / delete-file / create-folder rewritten onto `files-add`, `files-upload-dragger` + `files-upload-submit`, `file-actions` → Delete → `file-delete-submit` |

## Verification

- `TestReactCreateProjectSmoke` — **6/6 green** on 6.4.0 (create from template / Excel / zip, copy, list, history)
- `TestPermanentDeleteAfterRefreshUi` — **2/2 green** (exercises project delete through the new overflow menu)
- `TestReactSaveProjectSmoke` — still red at the Files-tab upload step; being worked on

## Related

Also filed while validating this: **EPBDS-16316** — creating a project from an OpenAPI specification fails with HTTP 500 in 6.4.0 (server-side NPE, reproducible without the UI). That blocks 19 test classes / 38 methods in this suite and is a product bug, not automation.

## Note on the diff

This PR targets `ui_migration`, whose remote copy is 19 commits behind the local branch, so the diff also shows those earlier migration commits. Only the last commit belongs to this change.